### PR TITLE
Add cookbook example for legal document extraction

### DIFF
--- a/cookbook/__init__.py
+++ b/cookbook/__init__.py
@@ -1,0 +1,3 @@
+# Cookbook examples package
+
+__all__ = []

--- a/cookbook/legal_extraction.py
+++ b/cookbook/legal_extraction.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from open_xtract import OpenXtract
+
+
+class ContractSummary(BaseModel):
+    party_a: str
+    party_b: str
+    effective_date: str
+    term_months: int
+    governing_law: str
+    termination_clause: str
+
+
+def extract_contract_summary(text: str, ox: OpenXtract | None = None) -> ContractSummary:
+    """Extract a structured summary of a legal contract from raw text.
+
+    This uses OpenXtract's text extraction to produce a structured `ContractSummary`.
+    Provide your own `OpenXtract` instance if you want to customize the model or settings.
+    """
+    client = ox or OpenXtract()
+    return client.extract_text(text, ContractSummary)
+
+
+def main() -> None:
+    sample_text = (
+        "This Master Service Agreement (MSA) is entered into by ACME Corp (\"ACME\") and "
+        "BetaCorp (\"BETA\") effective on January 1, 2024. The governing law is Delaware. "
+        "The initial term is 12 months. The agreement may be terminated for cause with 30 days notice."
+    )
+    result = extract_contract_summary(sample_text)
+    print(result.model_dump())
+
+
+__all__ = ["ContractSummary", "extract_contract_summary", "main"]

--- a/tests/test_cookbook_legal.py
+++ b/tests/test_cookbook_legal.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Any
+
+import open_xtract.main as ox_module
+from pydantic import BaseModel
+
+from cookbook.legal_extraction import ContractSummary, extract_contract_summary
+
+
+class _FakeStructured:
+    def __init__(self, schema: type[BaseModel]) -> None:
+        self._schema = schema
+
+    def invoke(self, _messages: list[Any]) -> BaseModel:
+        # Populate fields with type-safe dummy values
+        values: dict[str, Any] = {}
+        for name, field in self._schema.model_fields.items():
+            anno = field.annotation
+            if anno in (int, float):
+                values[name] = 0
+            elif anno is bool:
+                values[name] = False
+            else:
+                values[name] = "ok"
+        return self._schema.model_validate(values)
+
+
+class _FakeChatOpenAI:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: D401
+        pass
+
+    def with_structured_output(self, schema: type[BaseModel]) -> _FakeStructured:
+        return _FakeStructured(schema)
+
+
+def test_extract_contract_summary_monkeypatched(monkeypatch: Any) -> None:
+    # Swap out the real ChatOpenAI with our fake structured LLM
+    monkeypatch.setattr(ox_module, "ChatOpenAI", _FakeChatOpenAI)
+
+    text = (
+        "This Agreement is between ACME and BetaCorp effective Jan 1, 2024 under Delaware law. "
+        "The term is 12 months and includes a termination for cause clause."
+    )
+
+    result = extract_contract_summary(text)
+
+    assert isinstance(result, ContractSummary)
+    # Spot-check types/values from our fake
+    assert isinstance(result.party_a, str)
+    assert isinstance(result.term_months, int)


### PR DESCRIPTION
Add a cookbook folder with a sample script demonstrating legal document text extraction using OpenXtract and a mock test.

---
<a href="https://cursor.com/background-agent?bcId=bc-9cbb4fd4-3cb8-4632-894e-17570d0a9a49">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9cbb4fd4-3cb8-4632-894e-17570d0a9a49">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

