### PR TITLE
feat(vision): bytes-only API; PDF→images; multimodal; tests; bump 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Turn documents into structured data**
 
-Open-source toolkit for extracting clean, structured data from text.
+Open-source toolkit for extracting clean, structured data from text, images, and PDFs.
 
 - [GitHub](https://github.com/Mellow-Artificial-Intelligence/open-xtract)
 - [PyPI](https://pypi.org/project/open-xtract/)
@@ -33,8 +33,20 @@ class InvoiceData(BaseModel):
 
 ox = OpenXtract(model="openai:gpt-5-nano")  # or any model
 
-# Extract from text
+# Extract from text (str)
 result = ox.extract("Total: $123.45 on 2025-03-01 from ACME", InvoiceData)
+print(result)
+
+# Extract from image (bytes)
+with open("/path/to/receipt.png", "rb") as f:
+    img_bytes = f.read()
+result = ox.extract(img_bytes, InvoiceData)
+print(result)
+
+# Extract from PDF (bytes) — each page is rendered to an image internally
+with open("/path/to/invoice.pdf", "rb") as f:
+    pdf_bytes = f.read()
+result = ox.extract(pdf_bytes, InvoiceData)
 print(result)
 ```
 

--- a/examples/cookbook.py
+++ b/examples/cookbook.py
@@ -6,7 +6,6 @@ load_dotenv()
 
 
 def main() -> None:
-
     class Resume(BaseModel):
         name: str = Field(description="The name of the person")
         email: str = Field(description="The email of the person")
@@ -18,7 +17,7 @@ def main() -> None:
 
     # Use xAI Grok
     ox = OpenXtract(model="xai:grok-4")
-    #ox = OpenXtract(model="openai:gpt-5-nano")
+    # ox = OpenXtract(model="openai:gpt-5-nano")
     result = ox.extract(
         "This is a test, I live at 123 Main St, Anytown, USA 12345. My email is test@test.com and my phone number is 123-456-7890.",
         Resume,

--- a/open_xtract/main.py
+++ b/open_xtract/main.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
-from pathlib import Path
+import base64
+import importlib
+import io
+import os
 from typing import Any
 
-from langchain_openai import ChatOpenAI
+from dotenv import load_dotenv
 from langchain_anthropic import ChatAnthropic
+from langchain_core.messages import HumanMessage
+from langchain_openai import ChatOpenAI
+from PIL import Image
 from pydantic import BaseModel
 
 # Import provider_map - try relative import first, fall back to absolute
@@ -12,9 +18,6 @@ try:
     from .provider_map import provider_map  # For when imported as a module
 except ImportError:
     from provider_map import provider_map  # type: ignore[no-redef] # For when run directly
-import os
-
-from dotenv import load_dotenv
 
 load_dotenv()
 
@@ -43,12 +46,101 @@ class OpenXtract:
         if self._provider == "anthropic":
             return ChatAnthropic(model=self._model, api_key=self._api_key)
         else:
-            return ChatOpenAI(
-                model=self._model, base_url=self._base_url, api_key=self._api_key
-            )
+            return ChatOpenAI(model=self._model, base_url=self._base_url, api_key=self._api_key)
 
-    def extract(self, file_path: str | Path, schema: type[BaseModel]) -> Any:
-        return self._llm.with_structured_output(schema).invoke(file_path)
+    def extract(self, data: str | bytes, schema: type[BaseModel]) -> Any:
+        """Extract structured data from text, images, or PDFs.
+
+        Requirements:
+        - Images must be provided as raw bytes (user reads file first)
+        - PDFs must be provided as raw bytes; each page is rendered to an image and sent
+        - Plain text is accepted as `str`
+        """
+
+        # Text input path: pass through unchanged
+        if isinstance(data, str):
+            return self._llm.with_structured_output(schema).invoke(data)
+
+        # Support bytes-like inputs
+        if isinstance(data, (bytes, bytearray, memoryview)):
+            binary = bytes(data)
+
+            # PDF detection by header
+            if binary[:5] == b"%PDF-":
+                try:
+                    fitz = importlib.import_module("fitz")  # PyMuPDF
+                except Exception as exc:  # pragma: no cover - import error path
+                    msg = (
+                        "PyMuPDF (pymupdf) is required for PDF page rendering. "
+                        "Install with `pip install pymupdf` or include the vision extra."
+                    )
+                    raise RuntimeError(msg) from exc
+
+                # Render each page to PNG bytes and add to message content
+                content_parts: list[dict[str, Any]] = [
+                    {"type": "text", "text": "Extract the structured data per the provided schema."}
+                ]
+                with fitz.open(stream=binary, filetype="pdf") as doc:
+                    for page in doc:
+                        pix = page.get_pixmap(dpi=200)
+                        png_bytes = pix.tobytes("png")
+                        b64 = base64.b64encode(png_bytes).decode("utf-8")
+                        if self._provider == "anthropic":
+                            content_parts.append(
+                                {
+                                    "type": "image",
+                                    "source": {
+                                        "type": "base64",
+                                        "media_type": "image/png",
+                                        "data": b64,
+                                    },
+                                }
+                            )
+                        else:
+                            data_url = f"data:image/png;base64,{b64}"
+                            content_parts.append(
+                                {"type": "image_url", "image_url": {"url": data_url}}
+                            )
+
+                return self._llm.with_structured_output(schema).invoke(
+                    [HumanMessage(content=content_parts)]
+                )
+
+            # Image bytes path: verify and send as multimodal
+            try:
+                with Image.open(io.BytesIO(binary)) as img:
+                    format_name = (img.format or "PNG").upper()
+            except Exception as exc:
+                raise ValueError("Unsupported binary input: expected image or PDF bytes") from exc
+
+            mime = "image/png" if format_name == "PNG" else f"image/{format_name.lower()}"
+            b64 = base64.b64encode(binary).decode("utf-8")
+
+            if self._provider == "anthropic":
+                content = [
+                    {
+                        "type": "text",
+                        "text": "Extract the structured data per the provided schema.",
+                    },
+                    {
+                        "type": "image",
+                        "source": {"type": "base64", "media_type": mime, "data": b64},
+                    },
+                ]
+            else:
+                data_url = f"data:{mime};base64,{b64}"
+                content = [
+                    {
+                        "type": "text",
+                        "text": "Extract the structured data per the provided schema.",
+                    },
+                    {"type": "image_url", "image_url": {"url": data_url}},
+                ]
+
+            return self._llm.with_structured_output(schema).invoke([HumanMessage(content=content)])
+
+        # Reject file paths or other unsupported types to keep API strict
+        raise TypeError("extract expects `str` for text or `bytes` for image/PDF content")
 
 
 __all__ = ["OpenXtract"]

--- a/open_xtract/provider_map.py
+++ b/open_xtract/provider_map.py
@@ -3,8 +3,11 @@ provider_map = {
     "openai": {"base_url": "https://api.openai.com/v1", "api_key": "OPENAI_API_KEY"},
     "openrouter": {"base_url": "https://openrouter.ai/api/v1", "api_key": "OPENROUTER_API_KEY"},
     "togetherai": {"base_url": "https://api.together.xyz/v1", "api_key": "TOGETHER_API_KEY"},
-    "groq": {"base_url": "https://api.groq.com/openai/v1", "api_key" : "GROQ_API_KEY"},
+    "groq": {"base_url": "https://api.groq.com/openai/v1", "api_key": "GROQ_API_KEY"},
     "cerebras": {"base_url": "https://api.cerebras.ai/v1", "api_key": "CEREBRAS_API_KEY"},
-    "google": {"base_url": "https://generativelanguage.googleapis.com/v1beta/openai/", "api_key": "GEMINI_API_KEY"},
-    "anthropic": {"base_url": None, "api_key": "ANTHROPIC_API_KEY"}
+    "google": {
+        "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/",
+        "api_key": "GEMINI_API_KEY",
+    },
+    "anthropic": {"base_url": None, "api_key": "ANTHROPIC_API_KEY"},
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "open-xtract"
-version = "0.1.0"
+version = "0.1.2"
 description = "Open-source framework that extracts structured data from PDFs. Bring your own OCR or LLM and extend to any file type."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_openxtract.py
+++ b/tests/test_openxtract.py
@@ -1,8 +1,14 @@
-from pathlib import Path
+import io
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+import pytest
 from open_xtract.main import OpenXtract
+from PIL import Image
 from pydantic import BaseModel
+
+NUM_PARTS_TEXT_PLUS_TWO_IMAGES = 3
+NUM_PARTS_TEXT_PLUS_THREE_IMAGES = 4
 
 
 class MockSchema(BaseModel):
@@ -40,9 +46,9 @@ class TestOpenXtract:
         # Create extractor
         extractor = OpenXtract(model="openai:gpt-4")
 
-        # Test extract method
-        file_path = Path("/test/file.txt")
-        result = extractor.extract(file_path, MockSchema)
+        # Test extract method (text input)
+        text_input = "name: test, value: 42"
+        result = extractor.extract(text_input, MockSchema)
 
         # Verify the result
         assert result.name == "test"
@@ -50,9 +56,177 @@ class TestOpenXtract:
 
         # Verify the mock was called correctly
         mock_llm.with_structured_output.assert_called_once_with(MockSchema)
-        mock_llm.with_structured_output.return_value.invoke.assert_called_once_with(file_path)
+        mock_llm.with_structured_output.return_value.invoke.assert_called_once_with(text_input)
 
         # Verify ChatOpenAI was created with correct parameters
         mock_chat_openai.assert_called_once_with(
             model="gpt-4", base_url="https://api.openai.com/v1", api_key="test-key"
         )
+
+    @patch("open_xtract.main.ChatOpenAI")
+    @patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"})
+    def test_extract_image_bytes_openai(self, mock_chat_openai):
+        mock_llm = Mock()
+        mock_response = MockSchema(name="img", value=1)
+        mock_llm.with_structured_output.return_value.invoke.return_value = mock_response
+        mock_chat_openai.return_value = mock_llm
+
+        # Patch HumanMessage to capture content
+        class FakeHumanMessage:
+            def __init__(self, content):
+                self.content = content
+
+        with patch("open_xtract.main.HumanMessage", FakeHumanMessage):
+            ox = OpenXtract(model="openai:gpt-4o-mini")
+            # Generate a small PNG in memory
+            buf = io.BytesIO()
+            Image.new("RGB", (2, 2), color=(255, 0, 0)).save(buf, format="PNG")
+            img_bytes = buf.getvalue()
+
+            result = ox.extract(img_bytes, MockSchema)
+
+        assert result.name == "img"
+        assert result.value == 1  # noqa: PLR2004
+
+        # Validate content structure
+        invoke_args, _ = mock_llm.with_structured_output.return_value.invoke.call_args
+        assert isinstance(invoke_args[0], list)
+        human_msg = invoke_args[0][0]
+        parts = human_msg.content
+        assert parts[0]["type"] == "text"
+        assert parts[1]["type"] == "image_url"
+        assert parts[1]["image_url"]["url"].startswith("data:image/png;base64,")
+
+    @patch("open_xtract.main.ChatAnthropic")
+    @patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"})
+    def test_extract_image_bytes_anthropic(self, mock_chat_anthropic):
+        mock_llm = Mock()
+        mock_response = MockSchema(name="img", value=2)
+        mock_llm.with_structured_output.return_value.invoke.return_value = mock_response
+        mock_chat_anthropic.return_value = mock_llm
+
+        class FakeHumanMessage:
+            def __init__(self, content):
+                self.content = content
+
+        with patch("open_xtract.main.HumanMessage", FakeHumanMessage):
+            ox = OpenXtract(model="anthropic:claude-3-5-sonnet")
+            buf = io.BytesIO()
+            Image.new("RGB", (2, 2), color=(0, 255, 0)).save(buf, format="PNG")
+            img_bytes = buf.getvalue()
+
+            result = ox.extract(img_bytes, MockSchema)
+
+        assert result.value == 2  # noqa: PLR2004
+        invoke_args, _ = mock_llm.with_structured_output.return_value.invoke.call_args
+        human_msg = invoke_args[0][0]
+        parts = human_msg.content
+        assert parts[0]["type"] == "text"
+        assert parts[1]["type"] == "image"
+        assert parts[1]["source"]["type"] == "base64"
+        assert parts[1]["source"]["media_type"].startswith("image/")
+
+    @patch("open_xtract.main.ChatOpenAI")
+    @patch("open_xtract.main.importlib.import_module")
+    @patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"})
+    def test_extract_pdf_bytes_openai(self, mock_import_module, mock_chat_openai):
+        mock_llm = Mock()
+        mock_response = MockSchema(name="pdf", value=3)
+        mock_llm.with_structured_output.return_value.invoke.return_value = mock_response
+        mock_chat_openai.return_value = mock_llm
+
+        # Fake fitz module
+        class FakePixmap:
+            def tobytes(self, fmt):
+                return b"PNGDATA"
+
+        class FakePage:
+            def get_pixmap(self, dpi):
+                return FakePixmap()
+
+        class FakeDoc:
+            def __enter__(self):
+                return self
+            def __exit__(self, exc_type, exc, tb):
+                return False
+            def __iter__(self):
+                return iter([FakePage(), FakePage()])
+
+        fake_fitz = SimpleNamespace(open=lambda stream, filetype: FakeDoc())
+        mock_import_module.return_value = fake_fitz
+
+        # Construct without __init__ to avoid creating real clients
+        ox = object.__new__(OpenXtract)
+        ox._provider = "openai"
+        ox._llm = mock_llm
+        pdf_bytes = b"%PDF- FAKE"
+        result = ox.extract(pdf_bytes, MockSchema)
+
+        assert result.value == 3  # noqa: PLR2004
+        invoke_args, _ = mock_llm.with_structured_output.return_value.invoke.call_args
+        human_msg = invoke_args[0][0]
+        parts = human_msg.content
+        # 1 text + 2 images
+        assert len(parts) == NUM_PARTS_TEXT_PLUS_TWO_IMAGES
+        assert parts[1]["type"] == "image_url"
+        assert parts[2]["type"] == "image_url"
+
+    @patch("open_xtract.main.ChatAnthropic")
+    @patch("open_xtract.main.importlib.import_module")
+    @patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"})
+    def test_extract_pdf_bytes_anthropic(self, mock_import_module, mock_chat_anthropic):
+        mock_llm = Mock()
+        mock_response = MockSchema(name="pdf", value=4)
+        mock_llm.with_structured_output.return_value.invoke.return_value = mock_response
+        mock_chat_anthropic.return_value = mock_llm
+
+        class FakePixmap:
+            def tobytes(self, fmt):
+                return b"PNGDATA"
+
+        class FakePage:
+            def get_pixmap(self, dpi):
+                return FakePixmap()
+
+        class FakeDoc:
+            def __enter__(self):
+                return self
+            def __exit__(self, exc_type, exc, tb):
+                return False
+            def __iter__(self):
+                return iter([FakePage(), FakePage(), FakePage()])
+
+        fake_fitz = SimpleNamespace(open=lambda stream, filetype: FakeDoc())
+        mock_import_module.return_value = fake_fitz
+
+        ox = object.__new__(OpenXtract)
+        ox._provider = "anthropic"
+        ox._llm = mock_llm
+        pdf_bytes = b"%PDF- FAKE"
+        result = ox.extract(pdf_bytes, MockSchema)
+
+        assert result.value == 4  # noqa: PLR2004
+        invoke_args, _ = mock_llm.with_structured_output.return_value.invoke.call_args
+        human_msg = invoke_args[0][0]
+        parts = human_msg.content
+        # 1 text + 3 images
+        assert len(parts) == NUM_PARTS_TEXT_PLUS_THREE_IMAGES
+        assert parts[1]["type"] == "image"
+        assert parts[2]["type"] == "image"
+        assert parts[3]["type"] == "image"
+
+    @patch("open_xtract.main.ChatOpenAI")
+    @patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"})
+    def test_extract_unsupported_bytes_raises(self, mock_chat_openai):
+        mock_chat_openai.return_value = Mock()
+        ox = OpenXtract(model="openai:gpt-4o-mini")
+        with pytest.raises(ValueError):
+            ox.extract(b"not-an-image-or-pdf", MockSchema)
+
+    @patch("open_xtract.main.ChatOpenAI")
+    @patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"})
+    def test_extract_invalid_type_raises(self, mock_chat_openai):
+        mock_chat_openai.return_value = Mock()
+        ox = OpenXtract(model="openai:gpt-4o-mini")
+        with pytest.raises(TypeError):
+            ox.extract(123, MockSchema)  # type: ignore[arg-type]

--- a/uv.lock
+++ b/uv.lock
@@ -1502,7 +1502,7 @@ wheels = [
 
 [[package]]
 name = "open-xtract"
-version = "0.1.0"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Adds bytes-only API for images/PDFs, renders PDF pages to PNG and sends multimodal content (OpenAI image_url / Anthropic base64). Expands tests for image bytes, PDF bytes, and error paths. Updates README. Informed by LangChain multimodal structured output guidance.