### PR TITLE
feat: Add api_key, base_url, and provider parameters to OpenXtract

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,16 @@ print(result)
 
 ### Input Types
 
-The model string format: `<provider>:<model_string>`
+The model can be specified in two formats:
 
-**Examples**: `"openai:gpt-4o"`, `"anthropic:claude-3-5-sonnet-20241022"`, `"xai:grok-beta"`
+1. **With colon**: `<provider>:<model_string>` (e.g., `"openai:gpt-4o"`)
+2. **Without colon**: `<model_string>` when `provider` parameter is provided separately
+
+**Examples**: 
+- `OpenXtract(model="openai:gpt-4o")` 
+- `OpenXtract(model="gpt-4o", provider="openai")`
+- `OpenXtract(model="anthropic:claude-3-5-sonnet-20241022")`
+- `OpenXtract(model="xai:grok-beta")`
 
 ```python
 from pydantic import BaseModel
@@ -115,6 +122,43 @@ ox = OpenXtract(model="xai:grok-beta")
 
 # OpenRouter (proxy to many models)
 ox = OpenXtract(model="openrouter:qwen/qwen-2.5-72b-instruct")
+```
+
+### Configuration Options
+
+You can configure OpenXtract using environment variables (default) or by passing parameters directly:
+
+```python
+# Using environment variables (default)
+# Set OPENAI_API_KEY=your-key in your environment or .env file
+ox = OpenXtract(model="openai:gpt-4o")
+
+# Pass API key directly
+ox = OpenXtract(
+    model="openai:gpt-4o",
+    api_key="sk-your-api-key-here"
+)
+
+# Pass API key and custom base URL
+ox = OpenXtract(
+    model="openai:gpt-4o",
+    api_key="sk-your-api-key-here",
+    base_url="https://api.openai.com/v1"
+)
+
+# Use model without colon when provider is specified separately
+ox = OpenXtract(
+    model="gpt-4o",
+    provider="openai",
+    api_key="sk-your-api-key-here"
+)
+
+# Parameters take priority over environment variables
+# This will use "direct-key" even if OPENAI_API_KEY is set
+ox = OpenXtract(
+    model="openai:gpt-4o",
+    api_key="direct-key"
+)
 ```
 
 ### Complex Data Structures


### PR DESCRIPTION
## Summary

This PR adds support for passing `api_key`, `base_url`, and `provider` parameters directly to the `OpenXtract` constructor, allowing users more flexibility in configuration while maintaining full backward compatibility.

## Changes

- **Added optional parameters** to `OpenXtract.__init__`:
  - `api_key: str | None = None` - Direct API key override
  - `base_url: str | None = None` - Custom base URL override  
  - `provider: str | None = None` - Provider specification for model strings without colon

- **Enhanced model string parsing**:
  - Supports both `"provider:model"` format (existing)
  - Supports `"model"` format when `provider` parameter is provided separately

- **Priority logic**:
  - Direct parameters take precedence over environment variables
  - Environment variables fall back to provider map defaults

- **Updated error messages** to mention both direct parameters and environment variable options

- **Added comprehensive tests** covering all new functionality

- **Updated documentation** with examples showing all configuration patterns

## Usage Examples

```python
# Existing way (still works)
ox = OpenXtract(model="openai:gpt-4o")

# New: Direct API key
ox = OpenXtract(model="openai:gpt-4o", api_key="sk-...")

# New: Model without colon
ox = OpenXtract(model="gpt-4o", provider="openai", api_key="sk-...")

# New: Custom base URL
ox = OpenXtract(model="openai:gpt-4o", api_key="sk-...", base_url="https://custom.com/v1")
```

## Testing

All 20 tests pass, including:
- ✅ Existing functionality (backward compatibility)
- ✅ Direct API key usage
- ✅ Direct base URL usage
- ✅ Model without colon format
- ✅ Priority logic validation
- ✅ Error handling

## Backward Compatibility

This change is fully backward compatible. All existing code using environment variables continues to work without modification.