### PR TITLE
feat: Allow model string without colon when api_key and base_url provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,9 @@ ox = OpenXtract(
 )
 
 # Pass API key and custom base URL
+# When api_key and base_url are provided, model can be used without colon
 ox = OpenXtract(
-    model="openai:gpt-4o",
+    model="gpt-4o",
     api_key="sk-your-api-key-here",
     base_url="https://api.openai.com/v1"
 )

--- a/open_xtract/main.py
+++ b/open_xtract/main.py
@@ -65,6 +65,7 @@ class OpenXtract:
                 suggestions = [
                     "Use the format 'provider:model' (e.g., 'openai:gpt-4o')",
                     "Or use 'model' with provider parameter: OpenXtract(model='gpt-4o', provider='openai')",
+                    "When api_key and base_url are provided, model can be used directly without colon",
                     "Available providers: " + ", ".join(provider_map.keys()),
                     "Examples: 'openai:gpt-4o-mini', 'anthropic:claude-3-5-sonnet', 'xai:grok-beta'"
                 ]
@@ -80,17 +81,23 @@ class OpenXtract:
                 ]
                 raise ConfigurationError(msg, suggestions)
         else:
-            # Format: "model" - requires provider parameter
+            # Format: "model" - provider may be optional if api_key and base_url are provided
             model = self._model_string
             if not self._provider_param:
-                msg = "Provider required when model string doesn't include provider"
-                suggestions = [
-                    "Use the format 'provider:model' (e.g., 'openai:gpt-4o')",
-                    "Or provide provider parameter: OpenXtract(model='gpt-4o', provider='openai')",
-                    "Available providers: " + ", ".join(provider_map.keys())
-                ]
-                raise ConfigurationError(msg, suggestions)
-            provider = self._provider_param
+                # If api_key and base_url are provided, default to "openai" (OpenAI-compatible)
+                if self._api_key_param is not None and self._base_url_param is not None:
+                    provider = "openai"
+                else:
+                    msg = "Provider required when model string doesn't include provider"
+                    suggestions = [
+                        "Use the format 'provider:model' (e.g., 'openai:gpt-4o')",
+                        "Or provide provider parameter: OpenXtract(model='gpt-4o', provider='openai')",
+                        "Or provide api_key and base_url to use model string directly",
+                        "Available providers: " + ", ".join(provider_map.keys())
+                    ]
+                    raise ConfigurationError(msg, suggestions)
+            else:
+                provider = self._provider_param
 
         if not model:
             msg = "Model name cannot be empty"

--- a/tests/test_openxtract.py
+++ b/tests/test_openxtract.py
@@ -386,3 +386,23 @@ class TestOpenXtract:
                 model="claude-3-5-sonnet",
                 api_key="test-anthropic-key-12345"
             )
+
+    @patch("open_xtract.main.ChatOpenAI")
+    def test_model_without_colon_when_api_key_and_base_url_provided(self, mock_chat_openai):
+        """Test that model string can be used without colon when api_key and base_url are provided."""
+        with patch.dict(os.environ, {}, clear=True):  # Clear all environment variables
+            extractor = OpenXtract(
+                model="gpt-4o",
+                api_key="test-api-key-12345",
+                base_url="https://api.openai.com/v1"
+            )
+
+            assert extractor._provider == "openai"
+            assert extractor._model == "gpt-4o"
+            assert extractor._api_key == "test-api-key-12345"
+            assert extractor._base_url == "https://api.openai.com/v1"
+            mock_chat_openai.assert_called_once_with(
+                model="gpt-4o",
+                base_url="https://api.openai.com/v1",
+                api_key="test-api-key-12345"
+            )


### PR DESCRIPTION
## Summary

This PR enhances the flexibility of the `OpenXtract` constructor by allowing model strings without a colon when `api_key` and `base_url` are provided directly. This simplifies configuration when using custom endpoints or OpenAI-compatible APIs.

## Changes

- **Model string flexibility**: When `api_key` and `base_url` are both provided, the model string can be used directly without requiring a colon separator
- **Automatic provider detection**: Defaults to "openai" provider when both parameters are provided (since `ChatOpenAI` works with OpenAI-compatible APIs)
- **Updated error messages**: Error messages now mention this option when appropriate
- **Added test**: Comprehensive test coverage for the new behavior
- **Updated documentation**: README examples updated to reflect this capability

## Usage Example

```python
# Now works without colon when api_key and base_url are provided
ox = OpenXtract(
    model="gpt-4o",
    api_key="sk-your-api-key-here",
    base_url="https://api.openai.com/v1"
)
```

## Testing

All 21 tests pass, including the new test for this functionality.

## Backward Compatibility

Fully backward compatible - all existing code continues to work unchanged.