### PR TITLE
feat: Add automated PyPI release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,5 +64,5 @@ jobs:
         # Option 2: API token (fallback if trusted publishing not set up)
         # Uncomment the following and comment out trusted-publisher above:
         # with:
-        #   password: ${{ secrets.PYPI_API_TOKEN }}
+        #   password: ${{ secrets.PYPI_KEY }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Releases are automated via GitHub Actions. To release a new version:
 
 2. **OR use API token** (alternative):
    - Create an API token on PyPI
-   - Add it as a GitHub secret named `PYPI_API_TOKEN`
+   - Add it as a GitHub secret named `PYPI_KEY`
    - Update `.github/workflows/release.yml` to use the token instead of trusted publishing
 
 ### Release Process


### PR DESCRIPTION
## Summary

This PR adds automated PyPI release functionality using GitHub Actions. Releases will be automatically published to PyPI when a GitHub release is created.

## Changes

- **Added `.github/workflows/release.yml`**: GitHub Actions workflow that:
  - Triggers on GitHub releases (when you publish a release)
  - Can also be triggered manually via workflow dispatch
  - Builds the package using `build`
  - Validates that the tag version matches `pyproject.toml`
  - Publishes to PyPI using trusted publishing (recommended) or API token

- **Updated `CONTRIBUTING.md`**: Added "Releasing to PyPI" section with:
  - Prerequisites for setting up PyPI trusted publishing
  - Step-by-step release process
  - Instructions for both trusted publishing and API token methods

## Setup Required

Before using this workflow, you need to set up PyPI trusted publishing:

1. Go to [PyPI Account Settings](https://pypi.org/manage/account/)
2. Navigate to **API tokens** → **Add API token** → **Trusted publisher**
3. Add your GitHub repository: `Mellow-Artificial-Intelligence/open-xtract`
4. The workflow will automatically authenticate using GitHub's OIDC

Alternatively, you can use an API token by:
- Creating an API token on PyPI
- Adding it as a GitHub secret named `PYPI_KEY`
- Updating the workflow to use the token instead

## Usage

After merging, to release a new version:

1. Update version in `pyproject.toml`
2. Commit and push
3. Create a GitHub release with tag `v0.1.3` (must match version, prefixed with 'v')
4. The workflow will automatically build and publish to PyPI