### PR TITLE
chore: remove unused cli entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,6 @@ dev = [
     "pre-commit>=3.7.0",
 ]
 
-[project.scripts]
-open-xtract = "open_xtract:main"
-
 [project.urls]
 Homepage = "https://mellow-artificial-intelligence.github.io/open-xtract/"
 


### PR DESCRIPTION
## Summary
- remove the unused `open-xtract` console script entry from pyproject to avoid a broken CLI
- keep package focused on library usage only

## Testing
- not run (config change only)