### PR TITLE
Fix critical security vulnerabilities: SSRF, hardcoded credentials, unsandboxed workflows

### DIFF
--- a/src/open_xtract/_extract.py
+++ b/src/open_xtract/_extract.py
@@ -25,7 +25,9 @@ def _validate_url(url: str) -> None:
     parsed = urlparse(url)
 
     if parsed.scheme not in ("http", "https"):
-        raise UrlFetchError(f"Invalid URL scheme: {parsed.scheme!r}. Only http and https are allowed.")
+        raise UrlFetchError(
+            f"Invalid URL scheme: {parsed.scheme!r}. Only http and https are allowed."
+        )
 
     hostname = parsed.hostname
     if not hostname:
@@ -34,11 +36,13 @@ def _validate_url(url: str) -> None:
     try:
         ip = ipaddress.ip_address(hostname)
         if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
-            raise UrlFetchError("URLs pointing to private or internal network addresses are not allowed.")
+            raise UrlFetchError(
+                "URLs pointing to private or internal network addresses are not allowed."
+            )
     except ValueError:
         # hostname is not an IP literal — check for localhost aliases
         if hostname.lower() in ("localhost", "localhost.localdomain"):
-            raise UrlFetchError("URLs pointing to localhost are not allowed.")
+            raise UrlFetchError("URLs pointing to localhost are not allowed.") from None
 
 
 def _get_media_url(url: str):

--- a/src/open_xtract/_extract.py
+++ b/src/open_xtract/_extract.py
@@ -1,6 +1,7 @@
 """Core extraction functionality."""
 
 import asyncio
+import ipaddress
 import os
 from typing import TypeVar
 from urllib.parse import urlparse
@@ -17,6 +18,27 @@ IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".svg"}
 AUDIO_EXTENSIONS = {".mp3", ".wav", ".ogg", ".flac", ".aac", ".m4a"}
 VIDEO_EXTENSIONS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".wmv"}
 DOCUMENT_EXTENSIONS = {".pdf", ".doc", ".docx", ".txt", ".html", ".csv", ".xls", ".xlsx"}
+
+
+def _validate_url(url: str) -> None:
+    """Validate URL to prevent SSRF attacks."""
+    parsed = urlparse(url)
+
+    if parsed.scheme not in ("http", "https"):
+        raise UrlFetchError(f"Invalid URL scheme: {parsed.scheme!r}. Only http and https are allowed.")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise UrlFetchError("Invalid URL: no hostname found.")
+
+    try:
+        ip = ipaddress.ip_address(hostname)
+        if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
+            raise UrlFetchError("URLs pointing to private or internal network addresses are not allowed.")
+    except ValueError:
+        # hostname is not an IP literal — check for localhost aliases
+        if hostname.lower() in ("localhost", "localhost.localdomain"):
+            raise UrlFetchError("URLs pointing to localhost are not allowed.")
 
 
 def _get_media_url(url: str):
@@ -80,6 +102,7 @@ def extract(
         )
 
     try:
+        _validate_url(url)
         agent = Agent(model, instructions=instructions, output_type=schema)
         media_url = _get_media_url(url)
         result = agent.run_sync(

--- a/src/open_xtract/_temporal.py
+++ b/src/open_xtract/_temporal.py
@@ -8,7 +8,6 @@ from typing import Any
 from urllib.parse import urlparse
 from uuid import uuid4
 
-import temporalio.worker
 from dotenv import load_dotenv
 from pydantic import BaseModel
 from pydantic_ai import Agent, AudioUrl, DocumentUrl, ImageUrl, VideoUrl
@@ -17,7 +16,7 @@ from temporalio.client import Client
 from temporalio.worker import Worker
 
 from ._docker import start_temporal_server
-from ._extract import AUDIO_EXTENSIONS, IMAGE_EXTENSIONS, VIDEO_EXTENSIONS
+from ._extract import AUDIO_EXTENSIONS, IMAGE_EXTENSIONS, VIDEO_EXTENSIONS, _validate_url
 
 # Load environment variables from .env file
 load_dotenv(Path.cwd() / ".env")
@@ -112,6 +111,8 @@ async def run_durable_extraction(
     Raises:
         RuntimeError: If Docker or Temporal is not available.
     """
+    _validate_url(url)
+
     start_temporal_server(with_ui=temporal_ui)
 
     client = await Client.connect("localhost:7233")
@@ -129,7 +130,6 @@ async def run_durable_extraction(
         task_queue=TASK_QUEUE,
         workflows=[ExtractionWorkflow],
         activities=[extract_activity],
-        workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
     ):
         result = await client.execute_workflow(
             ExtractionWorkflow.run,

--- a/src/open_xtract/docker-compose.temporal.yml
+++ b/src/open_xtract/docker-compose.temporal.yml
@@ -3,14 +3,14 @@ services:
     container_name: open-xtract-temporal-postgresql
     image: postgres:16
     environment:
-      POSTGRES_PASSWORD: temporal
-      POSTGRES_USER: temporal
+      POSTGRES_PASSWORD: ${TEMPORAL_DB_PASSWORD:-temporal}
+      POSTGRES_USER: ${TEMPORAL_DB_USER:-temporal}
     ports:
       - 5432:5432
     volumes:
       - temporal-postgresql-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U temporal"]
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER}"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -24,8 +24,8 @@ services:
     environment:
       - DB=postgres12
       - DB_PORT=5432
-      - POSTGRES_USER=temporal
-      - POSTGRES_PWD=temporal
+      - POSTGRES_USER=${TEMPORAL_DB_USER:-temporal}
+      - POSTGRES_PWD=${TEMPORAL_DB_PASSWORD:-temporal}
       - POSTGRES_SEEDS=postgresql
     ports:
       - 7233:7233

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -13,7 +13,55 @@ from open_xtract import (
     configure_logging,
     extract,
 )
-from open_xtract._extract import _get_media_url
+from open_xtract._extract import _get_media_url, _validate_url
+
+
+class TestValidateUrl:
+    def test_valid_https_url(self):
+        _validate_url("https://example.com/doc.pdf")  # should not raise
+
+    def test_valid_http_url(self):
+        _validate_url("http://example.com/doc.pdf")  # should not raise
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "ftp://example.com/file",
+            "file:///etc/passwd",
+            "gopher://evil.com",
+            "javascript:alert(1)",
+        ],
+    )
+    def test_rejects_non_http_schemes(self, url):
+        with pytest.raises(UrlFetchError, match="Invalid URL scheme"):
+            _validate_url(url)
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://127.0.0.1/admin",
+            "http://10.0.0.1/internal",
+            "http://172.16.0.1/internal",
+            "http://192.168.1.1/internal",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://0.0.0.0/",
+        ],
+    )
+    def test_rejects_private_ip_addresses(self, url):
+        with pytest.raises(UrlFetchError, match="private or internal"):
+            _validate_url(url)
+
+    def test_rejects_localhost(self):
+        with pytest.raises(UrlFetchError, match="localhost"):
+            _validate_url("http://localhost/admin")
+
+    def test_rejects_localhost_localdomain(self):
+        with pytest.raises(UrlFetchError, match="localhost"):
+            _validate_url("http://localhost.localdomain/admin")
+
+    def test_rejects_missing_hostname(self):
+        with pytest.raises(UrlFetchError, match="no hostname"):
+            _validate_url("http:///path")
 
 
 class TestGetMediaUrl:

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -337,7 +337,7 @@ wheels = [
 
 [[package]]
 name = "open-xtract"
-version = "0.1.4"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
- Add URL validation to prevent SSRF attacks (blocks private IPs, localhost,
  non-http schemes, cloud metadata endpoints like 169.254.169.254)
- Replace hardcoded PostgreSQL credentials in docker-compose with environment
  variable substitution (TEMPORAL_DB_USER, TEMPORAL_DB_PASSWORD)
- Remove UnsandboxedWorkflowRunner to re-enable Temporal's default sandboxing
- Add comprehensive tests for URL validation

https://claude.ai/code/session_013Q2Lbkp44Ne2Rf9X8tSLEw