### PR TITLE
docs: add runnable examples directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+- Add `examples/` directory with runnable scripts for invoice, receipt, and meeting-notes extraction.
+
 ## [0.4.0] - 2026-05-16
 - Accept `http://` URLs in addition to `https://`; previously, plain-HTTP URLs were silently treated as local file paths.
 - Raise `UrlFetchError` on non-2xx responses; previously, the HTML error body was passed to the LLM as media bytes.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,24 @@ result = extract(
 
 Set the corresponding provider credentials in your environment (e.g. `OPENAI_API_KEY`). `openextract` loads `.env` automatically.
 
+## Examples
+
+Runnable scripts live in the [`examples/`](examples/) directory. Each one takes the input path as the first argument and prints a JSON dump of the validated result:
+
+| Script                    | What it does                                            |
+| ------------------------- | ------------------------------------------------------- |
+| `invoice_extraction.py`   | PDF invoice -> structured line items                    |
+| `receipt_extraction.py`   | receipt image -> merchant, items, totals                |
+| `meeting_notes.py`        | audio -> summary, decisions, action items               |
+
+Run any example with `uv` once your provider credentials (e.g. `OPENAI_API_KEY`) are set:
+
+```bash
+uv run python examples/invoice_extraction.py ./invoices/q4.pdf
+```
+
+[See the examples/ directory](examples/) for the full source.
+
 ### Error handling
 
 ```python

--- a/examples/invoice_extraction.py
+++ b/examples/invoice_extraction.py
@@ -1,0 +1,50 @@
+"""Extract structured invoice data from a PDF file using openextract."""
+
+import sys
+from datetime import date
+
+from pydantic import BaseModel
+
+from openextract import extract
+
+
+class LineItem(BaseModel):
+    description: str
+    quantity: float
+    unit_price: float
+    total: float
+
+
+class Invoice(BaseModel):
+    invoice_number: str
+    issue_date: date
+    seller: str
+    buyer: str
+    line_items: list[LineItem]
+    subtotal: float
+    tax: float
+    total: float
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: uv run python examples/invoice_extraction.py <invoice.pdf>")
+        sys.exit(1)
+
+    input_file = sys.argv[1]
+
+    invoice = extract(
+        schema=Invoice,
+        model="openai:gpt-5",
+        input_file=input_file,
+        instructions=(
+            "Extract the invoice metadata, parties, every line item, and the "
+            "subtotal, tax, and total amounts. Use ISO 8601 for the issue date."
+        ),
+    )
+
+    print(invoice.model_dump_json(indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/meeting_notes.py
+++ b/examples/meeting_notes.py
@@ -1,0 +1,48 @@
+"""Extract structured meeting notes from an audio recording using openextract."""
+
+import sys
+from datetime import date
+
+from pydantic import BaseModel
+
+from openextract import extract
+
+
+class ActionItem(BaseModel):
+    description: str
+    owner: str
+    due: date | None = None
+
+
+class Meeting(BaseModel):
+    attendees: list[str]
+    date: date
+    summary: str
+    decisions: list[str]
+    action_items: list[ActionItem]
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: uv run python examples/meeting_notes.py <audio-file>")
+        sys.exit(1)
+
+    input_file = sys.argv[1]
+
+    meeting = extract(
+        schema=Meeting,
+        model="openai:gpt-5",
+        input_file=input_file,
+        instructions=(
+            "Listen to the meeting audio and produce structured notes. Include "
+            "every attendee, the meeting date, a concise summary, the decisions "
+            "that were made, and every action item with its owner and due date "
+            "when mentioned."
+        ),
+    )
+
+    print(meeting.model_dump_json(indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/receipt_extraction.py
+++ b/examples/receipt_extraction.py
@@ -1,0 +1,49 @@
+"""Extract structured receipt fields from an image using openextract."""
+
+import sys
+from datetime import date
+
+from pydantic import BaseModel
+
+from openextract import extract
+
+
+class ReceiptItem(BaseModel):
+    name: str
+    price: float
+    quantity: int = 1
+
+
+class Receipt(BaseModel):
+    merchant: str
+    transaction_date: date
+    items: list[ReceiptItem]
+    subtotal: float
+    tax: float
+    total: float
+    payment_method: str
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: uv run python examples/receipt_extraction.py <receipt-image-or-url>")
+        sys.exit(1)
+
+    input_file = sys.argv[1]
+
+    receipt = extract(
+        schema=Receipt,
+        model="openai:gpt-5",
+        input_file=input_file,
+        instructions=(
+            "Read the receipt image and extract the merchant, transaction date, "
+            "each purchased item with its price and quantity, the subtotal, tax, "
+            "total, and payment method."
+        ),
+    )
+
+    print(receipt.model_dump_json(indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds an `examples/` directory with three illustrative scripts: `invoice_extraction.py` (PDF), `receipt_extraction.py` (image), and `meeting_notes.py` (audio), each defining a Pydantic schema and calling `extract()` end-to-end.
- Updates `README.md` with an Examples section between Usage and Error handling, linking to the new directory.
- Adds an `[Unreleased]` entry to `CHANGELOG.md` (no version bump).