### PR TITLE
feat: accept bytes and file-like objects as input_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add `openextract` command-line interface for running extractions from the shell.
 - Add `examples/` directory with runnable scripts for invoice, receipt, and meeting-notes extraction.
 - Replace the substring-based exception classifier in `extract()` with typed provider-error matching against a tuple of known model-error base classes (`pydantic_ai.exceptions.ModelAPIError`, `openai.APIError`, `google.genai.errors.APIError`). Behavior change: an arbitrary exception whose message merely mentions "model" is no longer promoted to `ModelError`; it is now wrapped as `ExtractionError` unless the exception type is a subclass of a known provider error.
+- Accept raw `bytes` or any binary file-like object as `extract`'s `input_file`.
+- Add keyword-only `media_type` parameter for explicit MIME typing; required for `bytes` and file-like inputs, and overrides the guess for `str` paths and URLs.
 
 ## [0.4.0] - 2026-05-16
 - Accept `http://` URLs in addition to `https://`; previously, plain-HTTP URLs were silently treated as local file paths.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ result = extract(
 )
 ```
 
+### Bytes or file-like objects
+
+```python
+result = extract(schema=PdfInfo, model="openai:gpt-5", input_file=pdf_bytes, media_type="application/pdf")
+# A file-like object with .read() works too; pass media_type explicitly:
+result = extract(schema=PdfInfo, model="openai:gpt-5", input_file=open("q4.pdf", "rb"), media_type="application/pdf")
+```
+
 ### Choosing a model
 
 `model` follows the `pydantic-ai` provider prefix convention:
@@ -158,14 +166,15 @@ All `openextract` exceptions inherit from `ExtractionError`, so you can catch it
 
 ## API reference
 
-### `extract(schema, model, input_file, instructions=None)`
+### `extract(schema, model, input_file, instructions=None, *, media_type=None)`
 
-| Argument       | Type              | Description                                                      |
-| -------------- | ----------------- | ---------------------------------------------------------------- |
-| `schema`       | `type[BaseModel]` | A Pydantic model class describing the desired output shape.      |
-| `model`        | `str`             | A `pydantic-ai` model identifier (e.g. `"openai:gpt-5"`).        |
-| `input_file`   | `str`             | A local file path or an `https://` URL.                          |
-| `instructions` | `str \| None`     | Optional natural-language guidance for the model.                |
+| Argument       | Type                          | Description                                                                                                       |
+| -------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `schema`       | `type[BaseModel]`             | A Pydantic model class describing the desired output shape.                                                       |
+| `model`        | `str`                         | A `pydantic-ai` model identifier (e.g. `"openai:gpt-5"`).                                                         |
+| `input_file`   | `str \| bytes \| BinaryIO`    | A local file path, an `https://` URL, raw `bytes`, or a binary file-like object with a `.read()` method.          |
+| `instructions` | `str \| None`                 | Optional natural-language guidance for the model.                                                                 |
+| `media_type`   | `str \| None` (keyword-only)  | MIME type. Required for `bytes` and file-like inputs; overrides the guessed type for `str` inputs when provided.  |
 
 Returns an instance of `schema`.
 

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -2,7 +2,7 @@
 
 import mimetypes
 from pathlib import Path
-from typing import TypeVar
+from typing import BinaryIO, TypeVar
 
 import httpx
 from dotenv import load_dotenv
@@ -17,6 +17,10 @@ T = TypeVar("T", bound=BaseModel)
 _DEFAULT_MEDIA_TYPE = "application/octet-stream"
 _URL_PREFIXES = ("http://", "https://")
 _URL_FETCH_TIMEOUT = 30.0
+_BYTES_MEDIA_TYPE_REQUIRED = (
+    "media_type is required when input_file is bytes or a file-like object; "
+    "pass it explicitly, e.g. extract(..., media_type='application/pdf')."
+)
 
 
 def _collect_model_error_types() -> tuple[type[BaseException], ...]:
@@ -60,8 +64,8 @@ def _get_media_type(file_path: str) -> str:
     return media_type or _DEFAULT_MEDIA_TYPE
 
 
-def _get_media(file_path: str) -> tuple[bytes, str]:
-    """Read media bytes from a local path or http(s) URL and return (bytes, media_type)."""
+def _read_from_path(file_path: str) -> tuple[bytes, str]:
+    """Read bytes from a local path or http(s) URL; return (bytes, media_type)."""
     if file_path.startswith(_URL_PREFIXES):
         response = httpx.get(file_path, follow_redirects=True, timeout=_URL_FETCH_TIMEOUT)
         response.raise_for_status()
@@ -72,27 +76,67 @@ def _get_media(file_path: str) -> tuple[bytes, str]:
             header = response.headers.get("content-type", "").split(";", 1)[0].strip()
             if header:
                 media_type = header
-    else:
-        media_bytes = Path(file_path).read_bytes()
-        media_type = _get_media_type(file_path)
+        return media_bytes, media_type
 
-    return media_bytes, media_type
+    return Path(file_path).read_bytes(), _get_media_type(file_path)
 
 
-def extract(schema: type[T], model: str, input_file: str, instructions: str | None = None) -> T:
+def _get_media(
+    input_file: str | bytes | BinaryIO,
+    media_type: str | None = None,
+) -> tuple[bytes, str]:
+    """Resolve ``input_file`` to ``(bytes, media_type)``.
+
+    ``str`` is treated as a local path or http(s) URL. ``bytes`` and file-like
+    objects (anything with a ``.read()`` method) are passed through. For the
+    latter two, ``media_type`` is required.
+    """
+    if isinstance(input_file, str):
+        file_bytes, resolved_type = _read_from_path(input_file)
+        return file_bytes, media_type or resolved_type
+
+    if isinstance(input_file, bytes):
+        if media_type is None:
+            raise TypeError(_BYTES_MEDIA_TYPE_REQUIRED)
+        return input_file, media_type
+
+    if hasattr(input_file, "read"):
+        if media_type is None:
+            raise TypeError(_BYTES_MEDIA_TYPE_REQUIRED)
+        return input_file.read(), media_type
+
+    raise TypeError(
+        "input_file must be a str path/URL, bytes, or a file-like object with a .read() method."
+    )
+
+
+def extract(
+    schema: type[T],
+    model: str,
+    input_file: str | bytes | BinaryIO,
+    instructions: str | None = None,
+    *,
+    media_type: str | None = None,
+) -> T:
     """
     Extract structured data from a document, image, audio, or video file using an LLM.
 
     Args:
         schema: A Pydantic model class defining the expected output structure.
         model: The model identifier (e.g., 'openai:gpt-5').
-        input_file: A local file path or an http(s) URL to extract from.
+        input_file: A local file path, an ``http(s)://`` URL, raw ``bytes``, or
+            a binary file-like object with a ``.read()`` method. For ``bytes``
+            and file-like inputs, ``media_type`` must be provided.
         instructions: Optional natural-language guidance for the LLM.
+        media_type: Optional MIME type. Required for ``bytes`` and file-like
+            inputs; overrides the guess for ``str`` inputs when provided.
 
     Returns:
         An instance of the schema populated with extracted data.
 
     Raises:
+        TypeError: If ``input_file`` is bytes or file-like and ``media_type``
+            is not provided.
         UrlFetchError: If the URL cannot be fetched or returns a non-2xx status.
         SchemaValidationError: If the model output doesn't match the schema.
         ModelError: If there's an error communicating with the model API.
@@ -100,7 +144,7 @@ def extract(schema: type[T], model: str, input_file: str, instructions: str | No
     """
     try:
         load_dotenv()
-        file_bytes, file_type = _get_media(file_path=input_file)
+        file_bytes, file_type = _get_media(input_file, media_type=media_type)
         agent = Agent(
             model,
             instructions=instructions,
@@ -119,6 +163,8 @@ def extract(schema: type[T], model: str, input_file: str, instructions: str | No
         raise UrlFetchError(f"Failed to fetch URL: {e}") from e
     except ValidationError as e:
         raise SchemaValidationError(f"Model output did not match schema: {e}") from e
+    except TypeError:
+        raise
     except Exception as e:
         if isinstance(e, _MODEL_ERROR_TYPES):
             raise ModelError(f"Model API error: {e}") from e

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,10 +1,12 @@
 """Tests for openextract._extract."""
 
+import io
 from unittest.mock import MagicMock
 
 import httpx
 import pytest
 from pydantic import BaseModel, ValidationError
+from pydantic_ai import BinaryContent
 
 from openextract import (
     ExtractionError,
@@ -337,3 +339,106 @@ class TestExtract:
         # The new classifier should NOT promote this to ModelError just because
         # the message mentions "model".
         assert not isinstance(exc_info.value, ModelError)
+
+
+# ---------------------------------------------------------------------------
+# extract: input_file polymorphism
+# ---------------------------------------------------------------------------
+
+
+def _binary_content_arg(agent_instance) -> BinaryContent:
+    """Pull the BinaryContent that was passed to agent.run_sync."""
+    (call_args,) = agent_instance.run_sync.call_args.args
+    binary = next(part for part in call_args if isinstance(part, BinaryContent))
+    return binary
+
+
+class TestExtractInputs:
+    def test_bytes_input_with_media_type(self, mocker):
+        expected = _Person(name="Grace", age=85)
+        _, agent_instance = _make_agent_mock(mocker, output=expected)
+
+        result = extract(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_file=b"raw-payload",
+            media_type="application/pdf",
+        )
+
+        assert result is expected
+        binary = _binary_content_arg(agent_instance)
+        assert binary.data == b"raw-payload"
+        assert binary.media_type == "application/pdf"
+
+    def test_filelike_input_with_media_type(self, mocker):
+        expected = _Person(name="Ada", age=36)
+        _, agent_instance = _make_agent_mock(mocker, output=expected)
+        buffer = io.BytesIO(b"buffered-bytes")
+
+        result = extract(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_file=buffer,
+            media_type="image/png",
+        )
+
+        assert result is expected
+        binary = _binary_content_arg(agent_instance)
+        assert binary.data == b"buffered-bytes"
+        assert binary.media_type == "image/png"
+        # Caller owns the handle; we must not close it.
+        assert not buffer.closed
+
+    def test_bytes_input_without_media_type_raises(self, mocker):
+        _make_agent_mock(mocker, output=_Person(name="x", age=1))
+
+        with pytest.raises(TypeError, match="media_type is required"):
+            extract(schema=_Person, model="openai:gpt-5", input_file=b"abc")
+
+    def test_filelike_input_without_media_type_raises(self, mocker):
+        _make_agent_mock(mocker, output=_Person(name="x", age=1))
+
+        with pytest.raises(TypeError, match="media_type is required"):
+            extract(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_file=io.BytesIO(b"abc"),
+            )
+
+    def test_str_input_still_works(self, tmp_path, mocker):
+        local = tmp_path / "doc.txt"
+        local.write_bytes(b"file-bytes")
+        expected = _Person(name="Linus", age=54)
+        _, agent_instance = _make_agent_mock(mocker, output=expected)
+
+        result = extract(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_file=str(local),
+        )
+
+        assert result is expected
+        binary = _binary_content_arg(agent_instance)
+        assert binary.data == b"file-bytes"
+        assert binary.media_type == "text/plain"
+
+    def test_str_input_media_type_override(self, tmp_path, mocker):
+        local = tmp_path / "doc.txt"
+        local.write_bytes(b"file-bytes")
+        _, agent_instance = _make_agent_mock(mocker, output=_Person(name="x", age=1))
+
+        extract(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_file=str(local),
+            media_type="text/markdown",
+        )
+
+        binary = _binary_content_arg(agent_instance)
+        assert binary.media_type == "text/markdown"
+
+    def test_unsupported_input_type_raises_type_error(self, mocker):
+        _make_agent_mock(mocker, output=_Person(name="x", age=1))
+
+        with pytest.raises(TypeError, match="input_file must be"):
+            extract(schema=_Person, model="openai:gpt-5", input_file=12345)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- `extract()` now accepts raw `bytes` or any binary file-like object (anything with `.read() -> bytes`) for `input_file`, in addition to local paths and `https://` URLs.
- New keyword-only `media_type` parameter: required for `bytes` and file-like inputs (raises `TypeError` with a helpful message otherwise) and overrides the guessed MIME type for `str` inputs when supplied.
- File-like inputs are read once and never closed; the caller retains ownership of the handle.
- README gains a short bytes/file-like snippet under Usage and an updated API reference; CHANGELOG records the change under `## [Unreleased]`.