### PR TITLE
refactor: classify provider errors via typed exception matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 - Add `openextract` command-line interface for running extractions from the shell.
 - Add `examples/` directory with runnable scripts for invoice, receipt, and meeting-notes extraction.
+- Replace the substring-based exception classifier in `extract()` with typed provider-error matching against a tuple of known model-error base classes (`pydantic_ai.exceptions.ModelAPIError`, `openai.APIError`, `google.genai.errors.APIError`). Behavior change: an arbitrary exception whose message merely mentions "model" is no longer promoted to `ModelError`; it is now wrapped as `ExtractionError` unless the exception type is a subclass of a known provider error.
 
 ## [0.4.0] - 2026-05-16
 - Accept `http://` URLs in addition to `https://`; previously, plain-HTTP URLs were silently treated as local file paths.

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -19,6 +19,41 @@ _URL_PREFIXES = ("http://", "https://")
 _URL_FETCH_TIMEOUT = 30.0
 
 
+def _collect_model_error_types() -> tuple[type[BaseException], ...]:
+    """Collect known provider/model error base classes that are importable.
+
+    Each import is guarded so a missing optional provider does not break the
+    package. The returned tuple is suitable for use with ``isinstance``.
+    """
+    error_types: list[type[BaseException]] = []
+
+    try:
+        from pydantic_ai.exceptions import ModelAPIError
+
+        error_types.append(ModelAPIError)
+    except ImportError:  # pragma: no cover - pydantic-ai is a hard dependency
+        pass
+
+    try:
+        from openai import APIError as OpenAIAPIError
+
+        error_types.append(OpenAIAPIError)
+    except ImportError:  # pragma: no cover - openai extra is installed
+        pass
+
+    try:
+        from google.genai.errors import APIError as GoogleAPIError
+
+        error_types.append(GoogleAPIError)
+    except ImportError:  # pragma: no cover - google extra is installed
+        pass
+
+    return tuple(error_types)
+
+
+_MODEL_ERROR_TYPES: tuple[type[BaseException], ...] = _collect_model_error_types()
+
+
 def _get_media_type(file_path: str) -> str:
     """Return the MIME type for a file path (e.g. 'application/pdf')."""
     media_type, _ = mimetypes.guess_type(file_path)
@@ -85,6 +120,6 @@ def extract(schema: type[T], model: str, input_file: str, instructions: str | No
     except ValidationError as e:
         raise SchemaValidationError(f"Model output did not match schema: {e}") from e
     except Exception as e:
-        if "api" in str(type(e).__module__).lower() or "model" in str(e).lower():
+        if isinstance(e, _MODEL_ERROR_TYPES):
             raise ModelError(f"Model API error: {e}") from e
         raise ExtractionError(f"Extraction failed: {e}") from e

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -279,21 +279,33 @@ class TestExtract:
         with pytest.raises(SchemaValidationError, match="Model output did not match schema"):
             extract(schema=_Person, model="openai:gpt-5", input_file=str(local))
 
-    def test_api_module_error_is_wrapped_as_model_error(self, tmp_path, mocker):
+    def test_pydantic_ai_model_api_error_is_wrapped_as_model_error(self, tmp_path, mocker):
         local = tmp_path / "input.txt"
         local.write_bytes(b"hello")
+        from pydantic_ai.exceptions import ModelHTTPError
 
-        class _ApiThing(Exception):
-            pass
-
-        # Force the exception's defining module to look like an "api" module.
-        _ApiThing.__module__ = "some.vendor.api.client"
-        _make_agent_mock(mocker, run_sync_side_effect=_ApiThing("upstream down"))
+        provider_error = ModelHTTPError(status_code=503, model_name="gpt-5", body="upstream down")
+        _make_agent_mock(mocker, run_sync_side_effect=provider_error)
 
         with pytest.raises(ModelError, match="Model API error"):
             extract(schema=_Person, model="openai:gpt-5", input_file=str(local))
 
-    def test_message_mentioning_model_is_wrapped_as_model_error(self, tmp_path, mocker):
+    def test_openai_api_error_is_wrapped_as_model_error(self, tmp_path, mocker):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hello")
+        from openai import APIError as OpenAIAPIError
+
+        class _FakeOpenAIError(OpenAIAPIError):
+            def __init__(self, message: str):
+                # Bypass OpenAIAPIError.__init__ to avoid constructing request/body objects.
+                Exception.__init__(self, message)
+
+        _make_agent_mock(mocker, run_sync_side_effect=_FakeOpenAIError("rate limited"))
+
+        with pytest.raises(ModelError, match="Model API error"):
+            extract(schema=_Person, model="openai:gpt-5", input_file=str(local))
+
+    def test_message_mentioning_model_is_wrapped_as_extraction_error(self, tmp_path, mocker):
         local = tmp_path / "input.txt"
         local.write_bytes(b"hello")
         _make_agent_mock(
@@ -301,7 +313,7 @@ class TestExtract:
             run_sync_side_effect=RuntimeError("unknown model identifier"),
         )
 
-        with pytest.raises(ModelError, match="Model API error"):
+        with pytest.raises(ExtractionError, match="Extraction failed: unknown model identifier"):
             extract(schema=_Person, model="openai:gpt-5", input_file=str(local))
 
     def test_generic_exception_is_wrapped_as_extraction_error(self, tmp_path, mocker):
@@ -311,3 +323,17 @@ class TestExtract:
 
         with pytest.raises(ExtractionError, match="Extraction failed: kaboom"):
             extract(schema=_Person, model="openai:gpt-5", input_file=str(local))
+
+    def test_message_mentioning_model_is_not_subclass_of_model_error(self, tmp_path, mocker):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hello")
+        _make_agent_mock(
+            mocker,
+            run_sync_side_effect=RuntimeError("the model said no"),
+        )
+
+        with pytest.raises(ExtractionError) as exc_info:
+            extract(schema=_Person, model="openai:gpt-5", input_file=str(local))
+        # The new classifier should NOT promote this to ModelError just because
+        # the message mentions "model".
+        assert not isinstance(exc_info.value, ModelError)


### PR DESCRIPTION
## Summary
- Replace the substring heuristic in `extract()` (`"api" in module name` or `"model" in message`) with `isinstance` checks against a tuple of known model-error base classes built once at module import time: `pydantic_ai.exceptions.ModelAPIError`, `openai.APIError`, and `google.genai.errors.APIError`. Each import is guarded by `try/except ImportError` so the package stays resilient if an optional provider is missing.
- Preserve existing behavior for `ValidationError -> SchemaValidationError` and `httpx.HTTPStatusError` / `httpx.RequestError -> UrlFetchError`.
- Update tests: drop the heuristic-driven tests and add coverage for a `pydantic-ai` `ModelHTTPError`, an `openai.APIError` subclass, and a plain `RuntimeError`. Add a `## [Unreleased]` entry to `CHANGELOG.md`.

### Behavior changes
- An arbitrary exception whose message merely mentions "model" is no longer auto-classified as `ModelError` — it now correctly becomes `ExtractionError` unless its type is in the known model-error list.
- Exceptions raised from modules whose name contains the substring "api" (for example `scrapy` or `openapi-client`) are no longer misclassified as `ModelError`.