### PR TITLE
feat: add async and batch extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Replace the substring-based exception classifier in `extract()` with typed provider-error matching against a tuple of known model-error base classes (`pydantic_ai.exceptions.ModelAPIError`, `openai.APIError`, `google.genai.errors.APIError`). Behavior change: an arbitrary exception whose message merely mentions "model" is no longer promoted to `ModelError`; it is now wrapped as `ExtractionError` unless the exception type is a subclass of a known provider error.
 - Accept raw `bytes` or any binary file-like object as `extract`'s `input_file`.
 - Add keyword-only `media_type` parameter for explicit MIME typing; required for `bytes` and file-like inputs, and overrides the guess for `str` paths and URLs.
+- Add `extract_async` for async extraction using `Agent.run`.
+- Add `extract_many` and `extract_many_async` for concurrent batch extraction with configurable concurrency and optional exception capture.
 
 ## [0.4.0] - 2026-05-16
 - Accept `http://` URLs in addition to `https://`; previously, plain-HTTP URLs were silently treated as local file paths.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ packages = ["src/openextract"]
 [dependency-groups]
 dev = [
     "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.1.0",
     "pytest-mock>=3.15.1",
     "ruff>=0.14.10",
@@ -60,6 +61,7 @@ ignore = ["UP047"]  # TypeVar pattern is valid for pydantic-ai compatibility
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
+asyncio_mode = "auto"
 
 [tool.coverage.run]
 branch = true

--- a/src/openextract/__init__.py
+++ b/src/openextract/__init__.py
@@ -2,11 +2,14 @@
 openextract - Extract structured data from documents, images, audio, and video using LLMs.
 """
 
-from ._extract import extract
+from ._extract import extract, extract_async, extract_many, extract_many_async
 from .exceptions import ExtractionError, ModelError, SchemaValidationError, UrlFetchError
 
 __all__ = [
     "extract",
+    "extract_async",
+    "extract_many",
+    "extract_many_async",
     "ExtractionError",
     "ModelError",
     "SchemaValidationError",

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -1,6 +1,8 @@
 """Core extraction functionality."""
 
+import asyncio
 import mimetypes
+from collections.abc import Iterable
 from pathlib import Path
 from typing import BinaryIO, TypeVar
 
@@ -110,6 +112,36 @@ def _get_media(
     )
 
 
+def _build_agent(schema: type[T], model: str, instructions: str | None) -> Agent:
+    """Construct the pydantic_ai Agent, handling the ollama output-type quirk."""
+    return Agent(
+        model,
+        instructions=instructions,
+        output_type=NativeOutput(schema) if model.startswith("ollama") else schema,
+    )
+
+
+def _build_run_inputs(file_bytes: bytes, file_type: str) -> list:
+    """Build the prompt inputs passed to the agent run."""
+    return [
+        "Extract the requested information from this document.",
+        BinaryContent(data=file_bytes, media_type=file_type),
+    ]
+
+
+def _map_exception(exc: BaseException) -> ExtractionError:
+    """Translate a low-level exception into the appropriate ExtractionError subclass."""
+    if isinstance(exc, httpx.HTTPStatusError):
+        return UrlFetchError(f"Failed to fetch URL: {exc.response.status_code}")
+    if isinstance(exc, httpx.RequestError):
+        return UrlFetchError(f"Failed to fetch URL: {exc}")
+    if isinstance(exc, ValidationError):
+        return SchemaValidationError(f"Model output did not match schema: {exc}")
+    if isinstance(exc, _MODEL_ERROR_TYPES):
+        return ModelError(f"Model API error: {exc}")
+    return ExtractionError(f"Extraction failed: {exc}")
+
+
 def extract(
     schema: type[T],
     model: str,
@@ -145,27 +177,109 @@ def extract(
     try:
         load_dotenv()
         file_bytes, file_type = _get_media(input_file, media_type=media_type)
-        agent = Agent(
-            model,
-            instructions=instructions,
-            output_type=NativeOutput(schema) if model.startswith("ollama") else schema,
-        )
-        result = agent.run_sync(
-            [
-                "Extract the requested information from this document.",
-                BinaryContent(data=file_bytes, media_type=file_type),
-            ]
-        )
+        agent = _build_agent(schema, model, instructions)
+        result = agent.run_sync(_build_run_inputs(file_bytes, file_type))
         return result.output
-    except httpx.HTTPStatusError as e:
-        raise UrlFetchError(f"Failed to fetch URL: {e.response.status_code}") from e
-    except httpx.RequestError as e:
-        raise UrlFetchError(f"Failed to fetch URL: {e}") from e
-    except ValidationError as e:
-        raise SchemaValidationError(f"Model output did not match schema: {e}") from e
     except TypeError:
         raise
+    except ExtractionError:
+        raise
     except Exception as e:
-        if isinstance(e, _MODEL_ERROR_TYPES):
-            raise ModelError(f"Model API error: {e}") from e
-        raise ExtractionError(f"Extraction failed: {e}") from e
+        raise _map_exception(e) from e
+
+
+async def extract_async(
+    schema: type[T],
+    model: str,
+    input_file: str | bytes | BinaryIO,
+    instructions: str | None = None,
+    *,
+    media_type: str | None = None,
+) -> T:
+    """Async sibling of :func:`extract`; uses ``Agent.run`` instead of ``run_sync``."""
+    try:
+        load_dotenv()
+        file_bytes, file_type = _get_media(input_file, media_type=media_type)
+        agent = _build_agent(schema, model, instructions)
+        result = await agent.run(_build_run_inputs(file_bytes, file_type))
+        return result.output
+    except TypeError:
+        raise
+    except ExtractionError:
+        raise
+    except Exception as e:
+        raise _map_exception(e) from e
+
+
+async def _gather_extractions(
+    schema: type[T],
+    model: str,
+    input_files: Iterable[str | bytes | BinaryIO],
+    instructions: str | None,
+    max_concurrency: int,
+    return_exceptions: bool,
+) -> list:
+    files = list(input_files)
+    semaphore = asyncio.Semaphore(max_concurrency)
+
+    async def _bounded(item):
+        async with semaphore:
+            return await extract_async(schema, model, item, instructions)
+
+    tasks = [_bounded(item) for item in files]
+    return await asyncio.gather(*tasks, return_exceptions=return_exceptions)
+
+
+def extract_many(
+    schema: type[T],
+    model: str,
+    input_files: Iterable[str | bytes | BinaryIO],
+    instructions: str | None = None,
+    *,
+    max_concurrency: int = 5,
+    return_exceptions: bool = False,
+) -> list:
+    """Run :func:`extract_async` over many inputs concurrently from sync code.
+
+    Args:
+        schema: A Pydantic model class defining the expected output structure.
+        model: The model identifier.
+        input_files: Iterable of paths, URLs, or already-resolved bytes.
+        instructions: Optional natural-language guidance.
+        max_concurrency: Maximum number of in-flight extractions.
+        return_exceptions: If True, exceptions are returned in-place instead of raised
+            (mirrors :func:`asyncio.gather`).
+
+    Returns:
+        A list of results (or exceptions, when ``return_exceptions=True``) in input order.
+    """
+    return asyncio.run(
+        _gather_extractions(
+            schema,
+            model,
+            input_files,
+            instructions,
+            max_concurrency,
+            return_exceptions,
+        )
+    )
+
+
+async def extract_many_async(
+    schema: type[T],
+    model: str,
+    input_files: Iterable[str | bytes | BinaryIO],
+    instructions: str | None = None,
+    *,
+    max_concurrency: int = 5,
+    return_exceptions: bool = False,
+) -> list:
+    """Async sibling of :func:`extract_many`."""
+    return await _gather_extractions(
+        schema,
+        model,
+        input_files,
+        instructions,
+        max_concurrency,
+        return_exceptions,
+    )

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,7 +1,8 @@
 """Tests for openextract._extract."""
 
+import asyncio
 import io
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
@@ -14,6 +15,9 @@ from openextract import (
     SchemaValidationError,
     UrlFetchError,
     extract,
+    extract_async,
+    extract_many,
+    extract_many_async,
 )
 from openextract._extract import _get_media, _get_media_type
 
@@ -43,6 +47,9 @@ def test_star_import_exposes_only_existing_names():
     exported = {name for name in namespace if not name.startswith("_")}
     assert exported == {
         "extract",
+        "extract_async",
+        "extract_many",
+        "extract_many_async",
         "ExtractionError",
         "ModelError",
         "SchemaValidationError",
@@ -340,6 +347,17 @@ class TestExtract:
         # the message mentions "model".
         assert not isinstance(exc_info.value, ModelError)
 
+    def test_passes_through_existing_extraction_error(self, tmp_path, mocker):
+        """If the wrapped code already raises an ExtractionError, it is not re-wrapped."""
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hello")
+        original = ModelError("already mapped")
+        _make_agent_mock(mocker, run_sync_side_effect=original)
+
+        with pytest.raises(ModelError) as exc_info:
+            extract(schema=_Person, model="openai:gpt-5", input_file=str(local))
+        assert exc_info.value is original
+
 
 # ---------------------------------------------------------------------------
 # extract: input_file polymorphism
@@ -442,3 +460,288 @@ class TestExtractInputs:
 
         with pytest.raises(TypeError, match="input_file must be"):
             extract(schema=_Person, model="openai:gpt-5", input_file=12345)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Async helpers and shared mock builder
+# ---------------------------------------------------------------------------
+
+
+def _make_async_agent_mock(mocker, output=None, run_side_effect=None):
+    """Patch openextract._extract.Agent and stub the async ``run`` method."""
+    agent_instance = MagicMock()
+    if run_side_effect is not None:
+        agent_instance.run = AsyncMock(side_effect=run_side_effect)
+    else:
+        run_result = MagicMock()
+        run_result.output = output
+        agent_instance.run = AsyncMock(return_value=run_result)
+    agent_cls = mocker.patch("openextract._extract.Agent", return_value=agent_instance)
+    return agent_cls, agent_instance
+
+
+# ---------------------------------------------------------------------------
+# extract_async
+# ---------------------------------------------------------------------------
+
+
+class TestExtractAsync:
+    async def test_returns_schema_instance_from_local_file(self, tmp_path, mocker):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hi")
+        expected = _Person(name="Grace", age=85)
+        agent_cls, agent_instance = _make_async_agent_mock(mocker, output=expected)
+
+        result = await extract_async(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_file=str(local),
+            instructions="extract",
+        )
+
+        assert result is expected
+        agent_cls.assert_called_once()
+        agent_instance.run.assert_awaited_once()
+
+    async def test_ollama_model_wraps_output_in_native_output(self, tmp_path, mocker):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hi")
+        expected = _Person(name="Linus", age=54)
+        agent_cls, _ = _make_async_agent_mock(mocker, output=expected)
+
+        result = await extract_async(
+            schema=_Person,
+            model="ollama:llama3",
+            input_file=str(local),
+        )
+
+        assert result is expected
+        output_type = agent_cls.call_args.kwargs["output_type"]
+        assert output_type is not _Person
+        assert type(output_type).__name__ == "NativeOutput"
+
+    async def test_http_status_error_is_wrapped(self, mocker):
+        response = MagicMock()
+        response.status_code = 502
+        err = httpx.HTTPStatusError("boom", request=MagicMock(), response=response)
+        mocker.patch("openextract._extract._get_media", side_effect=err)
+
+        with pytest.raises(UrlFetchError, match="502"):
+            await extract_async(schema=_Person, model="openai:gpt-5", input_file="https://x/y")
+
+    async def test_request_error_is_wrapped(self, mocker):
+        err = httpx.ConnectError("dns failure")
+        mocker.patch("openextract._extract._get_media", side_effect=err)
+
+        with pytest.raises(UrlFetchError, match="dns failure"):
+            await extract_async(schema=_Person, model="openai:gpt-5", input_file="https://x/y")
+
+    async def test_validation_error_is_wrapped(self, tmp_path, mocker):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hi")
+        try:
+            _Person(name="x", age="not-an-int")  # type: ignore[arg-type]
+        except ValidationError as exc:
+            validation_error = exc
+        _make_async_agent_mock(mocker, run_side_effect=validation_error)
+
+        with pytest.raises(SchemaValidationError, match="Model output did not match schema"):
+            await extract_async(schema=_Person, model="openai:gpt-5", input_file=str(local))
+
+    async def test_generic_exception_is_wrapped_as_extraction_error(self, tmp_path, mocker):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hi")
+        _make_async_agent_mock(mocker, run_side_effect=RuntimeError("kaboom"))
+
+        with pytest.raises(ExtractionError, match="Extraction failed: kaboom"):
+            await extract_async(schema=_Person, model="openai:gpt-5", input_file=str(local))
+
+    async def test_model_keyword_exception_is_not_promoted_to_model_error(self, tmp_path, mocker):
+        """Mirrors the sync extract() behavior: substring 'model' no longer triggers ModelError."""
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hi")
+        _make_async_agent_mock(mocker, run_side_effect=RuntimeError("unknown model identifier"))
+
+        with pytest.raises(ExtractionError) as exc_info:
+            await extract_async(schema=_Person, model="openai:gpt-5", input_file=str(local))
+        assert not isinstance(exc_info.value, ModelError)
+
+    async def test_missing_media_type_for_bytes_input_raises_type_error(self, mocker):
+        """TypeError from _get_media must propagate out of extract_async untouched."""
+        _make_async_agent_mock(mocker, output=_Person(name="x", age=1))
+
+        with pytest.raises(TypeError, match="media_type is required"):
+            await extract_async(schema=_Person, model="openai:gpt-5", input_file=b"abc")
+
+    async def test_passes_through_existing_extraction_error(self, tmp_path, mocker):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hi")
+        original = SchemaValidationError("already mapped")
+        _make_async_agent_mock(mocker, run_side_effect=original)
+
+        with pytest.raises(SchemaValidationError) as exc_info:
+            await extract_async(schema=_Person, model="openai:gpt-5", input_file=str(local))
+        assert exc_info.value is original
+
+
+# ---------------------------------------------------------------------------
+# extract_many
+# ---------------------------------------------------------------------------
+
+
+class TestExtractMany:
+    def test_preserves_input_order(self, tmp_path, mocker):
+        files = []
+        for i in range(4):
+            p = tmp_path / f"f{i}.txt"
+            p.write_bytes(b"x")
+            files.append(str(p))
+
+        people = [_Person(name=f"n{i}", age=i) for i in range(4)]
+        # Map each path to its expected person via side_effect.
+        path_to_person = dict(zip(files, people, strict=True))
+
+        async def fake_extract_async(schema, model, input_file, instructions=None):
+            # Tiny await yields control so tasks can interleave.
+            await asyncio.sleep(0)
+            return path_to_person[input_file]
+
+        mocker.patch("openextract._extract.extract_async", side_effect=fake_extract_async)
+
+        results = extract_many(schema=_Person, model="openai:gpt-5", input_files=files)
+
+        assert results == people
+
+    def test_max_concurrency_is_respected(self, tmp_path, mocker):
+        files = [str(tmp_path / f"f{i}.txt") for i in range(10)]
+        for f in files:
+            from pathlib import Path
+
+            Path(f).write_bytes(b"x")
+
+        in_flight = 0
+        peak = 0
+        lock = asyncio.Lock()
+
+        async def fake_extract_async(schema, model, input_file, instructions=None):
+            nonlocal in_flight, peak
+            async with lock:
+                in_flight += 1
+                peak = max(peak, in_flight)
+            await asyncio.sleep(0.01)
+            async with lock:
+                in_flight -= 1
+            return _Person(name=input_file, age=1)
+
+        mocker.patch("openextract._extract.extract_async", side_effect=fake_extract_async)
+
+        results = extract_many(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_files=files,
+            max_concurrency=3,
+        )
+
+        assert len(results) == 10
+        assert peak <= 3
+        assert peak >= 1
+
+    def test_fail_fast_propagates_first_error(self, tmp_path, mocker):
+        files = [str(tmp_path / f"f{i}.txt") for i in range(3)]
+
+        async def fake_extract_async(schema, model, input_file, instructions=None):
+            if input_file.endswith("f1.txt"):
+                raise ModelError("boom on f1")
+            await asyncio.sleep(0.01)
+            return _Person(name=input_file, age=1)
+
+        mocker.patch("openextract._extract.extract_async", side_effect=fake_extract_async)
+
+        with pytest.raises(ModelError, match="boom on f1"):
+            extract_many(schema=_Person, model="openai:gpt-5", input_files=files)
+
+    def test_return_exceptions_yields_mixed_list(self, tmp_path, mocker):
+        files = [str(tmp_path / f"f{i}.txt") for i in range(3)]
+
+        async def fake_extract_async(schema, model, input_file, instructions=None):
+            if input_file.endswith("f1.txt"):
+                raise ModelError("boom on f1")
+            return _Person(name=input_file, age=1)
+
+        mocker.patch("openextract._extract.extract_async", side_effect=fake_extract_async)
+
+        results = extract_many(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_files=files,
+            return_exceptions=True,
+        )
+
+        assert isinstance(results[0], _Person)
+        assert isinstance(results[1], ModelError)
+        assert isinstance(results[2], _Person)
+
+
+# ---------------------------------------------------------------------------
+# extract_many_async
+# ---------------------------------------------------------------------------
+
+
+class TestExtractManyAsync:
+    async def test_fail_fast_propagates_first_error(self, tmp_path, mocker):
+        files = [str(tmp_path / f"f{i}.txt") for i in range(3)]
+
+        async def fake_extract_async(schema, model, input_file, instructions=None):
+            if input_file.endswith("f0.txt"):
+                raise ModelError("boom first")
+            await asyncio.sleep(0.01)
+            return _Person(name=input_file, age=1)
+
+        mocker.patch("openextract._extract.extract_async", side_effect=fake_extract_async)
+
+        with pytest.raises(ModelError, match="boom first"):
+            await extract_many_async(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_files=files,
+            )
+
+    async def test_return_exceptions_yields_mixed_list(self, tmp_path, mocker):
+        files = [str(tmp_path / f"f{i}.txt") for i in range(3)]
+
+        async def fake_extract_async(schema, model, input_file, instructions=None):
+            if input_file.endswith("f1.txt"):
+                raise SchemaValidationError("bad schema")
+            return _Person(name=input_file, age=1)
+
+        mocker.patch("openextract._extract.extract_async", side_effect=fake_extract_async)
+
+        results = await extract_many_async(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_files=files,
+            return_exceptions=True,
+        )
+
+        assert isinstance(results[0], _Person)
+        assert isinstance(results[1], SchemaValidationError)
+        assert isinstance(results[2], _Person)
+
+    async def test_preserves_input_order(self, tmp_path, mocker):
+        files = [str(tmp_path / f"f{i}.txt") for i in range(5)]
+        expected = [_Person(name=f, age=i) for i, f in enumerate(files)]
+        mapping = dict(zip(files, expected, strict=True))
+
+        async def fake_extract_async(schema, model, input_file, instructions=None):
+            await asyncio.sleep(0)
+            return mapping[input_file]
+
+        mocker.patch("openextract._extract.extract_async", side_effect=fake_extract_async)
+
+        results = await extract_many_async(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_files=files,
+        )
+
+        assert results == expected

--- a/uv.lock
+++ b/uv.lock
@@ -624,6 +624,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "ruff" },
@@ -639,6 +640,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "ruff", specifier = ">=0.14.10" },
@@ -983,6 +985,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds `extract_async` as the async sibling of `extract()` using `Agent.run`.
- Adds `extract_many` and `extract_many_async` for concurrent batch extraction backed by `asyncio.gather`, with `max_concurrency` and `return_exceptions` controls and input-order preservation.
- Factors the ollama-aware agent build, run-input construction, and exception mapping into shared helpers so sync and async paths share one source of truth, leaving the existing `extract()` signature and semantics untouched.
- Adds `pytest-asyncio` (with `asyncio_mode = "auto"`) and expands the test suite to cover async success and error mapping, concurrency limits, fail-fast propagation, and `return_exceptions=True` mixed results, maintaining 100% line and branch coverage.