### PR TITLE
feat: optional retry with exponential backoff on ModelError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add keyword-only `media_type` parameter for explicit MIME typing; required for `bytes` and file-like inputs, and overrides the guess for `str` paths and URLs.
 - Add `extract_async` for async extraction using `Agent.run`.
 - Add `extract_many` and `extract_many_async` for concurrent batch extraction with configurable concurrency and optional exception capture.
+- Add optional `max_retries` and `retry_backoff` keyword arguments to `extract()` for retrying transient `ModelError` failures with exponential backoff and jitter. Default behavior is unchanged (no retries).
 
 ## [0.4.0] - 2026-05-16
 - Accept `http://` URLs in addition to `https://`; previously, plain-HTTP URLs were silently treated as local file paths.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,20 @@ result = extract(schema=PdfInfo, model="openai:gpt-5", input_file=pdf_bytes, med
 result = extract(schema=PdfInfo, model="openai:gpt-5", input_file=open("q4.pdf", "rb"), media_type="application/pdf")
 ```
 
+### Retry on transient model errors
+
+```python
+result = extract(
+    schema=PdfInfo,
+    model="openai:gpt-5",
+    input_file="./reports/q4.pdf",
+    max_retries=3,
+)
+```
+
+`max_retries` defaults to `0` (single attempt). When set, `extract` retries only on `ModelError` and sleeps `retry_backoff * (2 ** attempt)` seconds (with up to 25% jitter) between attempts. `retry_backoff` defaults to `1.0` second.
+
+
 ### Choosing a model
 
 `model` follows the `pydantic-ai` provider prefix convention:
@@ -166,15 +180,17 @@ All `openextract` exceptions inherit from `ExtractionError`, so you can catch it
 
 ## API reference
 
-### `extract(schema, model, input_file, instructions=None, *, media_type=None)`
+### `extract(schema, model, input_file, instructions=None, *, media_type=None, max_retries=0, retry_backoff=1.0)`
 
-| Argument       | Type                          | Description                                                                                                       |
-| -------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `schema`       | `type[BaseModel]`             | A Pydantic model class describing the desired output shape.                                                       |
-| `model`        | `str`                         | A `pydantic-ai` model identifier (e.g. `"openai:gpt-5"`).                                                         |
-| `input_file`   | `str \| bytes \| BinaryIO`    | A local file path, an `https://` URL, raw `bytes`, or a binary file-like object with a `.read()` method.          |
-| `instructions` | `str \| None`                 | Optional natural-language guidance for the model.                                                                 |
-| `media_type`   | `str \| None` (keyword-only)  | MIME type. Required for `bytes` and file-like inputs; overrides the guessed type for `str` inputs when provided.  |
+| Argument        | Type                          | Description                                                                                                       |
+| --------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `schema`        | `type[BaseModel]`             | A Pydantic model class describing the desired output shape.                                                       |
+| `model`         | `str`                         | A `pydantic-ai` model identifier (e.g. `"openai:gpt-5"`).                                                         |
+| `input_file`    | `str \| bytes \| BinaryIO`    | A local file path, an `https://` URL, raw `bytes`, or a binary file-like object with a `.read()` method.          |
+| `instructions`  | `str \| None`                 | Optional natural-language guidance for the model.                                                                 |
+| `media_type`    | `str \| None` (keyword-only)  | MIME type. Required for `bytes` and file-like inputs; overrides the guessed type for `str` inputs when provided.  |
+| `max_retries`   | `int` (keyword-only)          | Extra attempts after a `ModelError`. Defaults to `0` (no retry).                                                  |
+| `retry_backoff` | `float` (keyword-only)        | Base seconds for exponential backoff with jitter between retries.                                                 |
 
 Returns an instance of `schema`.
 

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import mimetypes
+import random
+import time
 from collections.abc import Iterable
 from pathlib import Path
 from typing import BinaryIO, TypeVar
@@ -142,6 +144,28 @@ def _map_exception(exc: BaseException) -> ExtractionError:
     return ExtractionError(f"Extraction failed: {exc}")
 
 
+def _extract_once(
+    schema: type[T],
+    model: str,
+    input_file: str | bytes | BinaryIO,
+    instructions: str | None,
+    media_type: str | None,
+) -> T:
+    """Perform a single sync extraction attempt, classifying exceptions on failure."""
+    try:
+        load_dotenv()
+        file_bytes, file_type = _get_media(input_file, media_type=media_type)
+        agent = _build_agent(schema, model, instructions)
+        result = agent.run_sync(_build_run_inputs(file_bytes, file_type))
+        return result.output
+    except TypeError:
+        raise
+    except ExtractionError:
+        raise
+    except Exception as e:
+        raise _map_exception(e) from e
+
+
 def extract(
     schema: type[T],
     model: str,
@@ -149,6 +173,8 @@ def extract(
     instructions: str | None = None,
     *,
     media_type: str | None = None,
+    max_retries: int = 0,
+    retry_backoff: float = 1.0,
 ) -> T:
     """
     Extract structured data from a document, image, audio, or video file using an LLM.
@@ -162,6 +188,12 @@ def extract(
         instructions: Optional natural-language guidance for the LLM.
         media_type: Optional MIME type. Required for ``bytes`` and file-like
             inputs; overrides the guess for ``str`` inputs when provided.
+        max_retries: Number of additional attempts to make after a ``ModelError``.
+            Defaults to 0 (no retries, single attempt). Only ``ModelError``
+            triggers a retry; other exceptions propagate immediately.
+        retry_backoff: Base backoff in seconds. Sleep between attempts is
+            ``retry_backoff * (2 ** attempt) * (1 + random.uniform(0, 0.25))``,
+            i.e. exponential backoff with up to 25% jitter.
 
     Returns:
         An instance of the schema populated with extracted data.
@@ -171,21 +203,19 @@ def extract(
             is not provided.
         UrlFetchError: If the URL cannot be fetched or returns a non-2xx status.
         SchemaValidationError: If the model output doesn't match the schema.
-        ModelError: If there's an error communicating with the model API.
+        ModelError: If retries (if any) are exhausted.
         ExtractionError: For other extraction failures.
     """
-    try:
-        load_dotenv()
-        file_bytes, file_type = _get_media(input_file, media_type=media_type)
-        agent = _build_agent(schema, model, instructions)
-        result = agent.run_sync(_build_run_inputs(file_bytes, file_type))
-        return result.output
-    except TypeError:
-        raise
-    except ExtractionError:
-        raise
-    except Exception as e:
-        raise _map_exception(e) from e
+    attempt = 0
+    while True:
+        try:
+            return _extract_once(schema, model, input_file, instructions, media_type)
+        except ModelError:
+            if attempt >= max_retries:
+                raise
+            delay = retry_backoff * (2**attempt) * (1 + random.uniform(0, 0.25))
+            time.sleep(delay)
+            attempt += 1
 
 
 async def extract_async(

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -463,6 +463,104 @@ class TestExtractInputs:
 
 
 # ---------------------------------------------------------------------------
+# extract retry behavior
+# ---------------------------------------------------------------------------
+
+
+class TestExtractRetry:
+    def test_no_retry_by_default_raises_immediately(self, mocker):
+        sleep_mock = mocker.patch("openextract._extract.time.sleep")
+        once = mocker.patch(
+            "openextract._extract._extract_once",
+            side_effect=ModelError("upstream down"),
+        )
+
+        with pytest.raises(ModelError, match="upstream down"):
+            extract(schema=_Person, model="openai:gpt-5", input_file="ignored")
+
+        assert once.call_count == 1
+        sleep_mock.assert_not_called()
+
+    def test_retry_succeeds_after_transient_model_errors(self, mocker):
+        sleep_mock = mocker.patch("openextract._extract.time.sleep")
+        expected = _Person(name="Grace", age=85)
+        once = mocker.patch(
+            "openextract._extract._extract_once",
+            side_effect=[ModelError("flaky"), ModelError("flaky"), expected],
+        )
+
+        result = extract(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_file="ignored",
+            max_retries=2,
+        )
+
+        assert result is expected
+        assert once.call_count == 3
+        assert sleep_mock.call_count == 2
+
+    def test_retry_exhausted_raises_last_model_error(self, mocker):
+        sleep_mock = mocker.patch("openextract._extract.time.sleep")
+        once = mocker.patch(
+            "openextract._extract._extract_once",
+            side_effect=ModelError("persistent"),
+        )
+
+        with pytest.raises(ModelError, match="persistent"):
+            extract(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_file="ignored",
+                max_retries=2,
+            )
+
+        assert once.call_count == 3
+        assert sleep_mock.call_count == 2
+
+    def test_backoff_schedule_uses_exponential_jitter(self, mocker):
+        sleep_mock = mocker.patch("openextract._extract.time.sleep")
+        mocker.patch(
+            "openextract._extract._extract_once",
+            side_effect=ModelError("nope"),
+        )
+
+        with pytest.raises(ModelError):
+            extract(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_file="ignored",
+                max_retries=3,
+                retry_backoff=1.0,
+            )
+
+        delays = [call.args[0] for call in sleep_mock.call_args_list]
+        assert len(delays) == 3
+        assert delays == sorted(delays)
+        assert 1.0 <= delays[0] <= 1.25
+        assert 2.0 <= delays[1] <= 2.5
+        assert 4.0 <= delays[2] <= 5.0
+
+    def test_schema_validation_error_is_not_retried(self, mocker):
+        sleep_mock = mocker.patch("openextract._extract.time.sleep")
+        once = mocker.patch(
+            "openextract._extract._extract_once",
+            side_effect=SchemaValidationError("bad shape"),
+        )
+
+        with pytest.raises(SchemaValidationError, match="bad shape"):
+            extract(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_file="ignored",
+                max_retries=3,
+            )
+
+        assert once.call_count == 1
+        sleep_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Async helpers and shared mock builder
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add optional `max_retries` and `retry_backoff` keyword-only arguments to `extract()` for retrying transient `ModelError` failures.
- Refactor `extract()` so its body lives in a single-attempt `_extract_once` helper; the public function wraps it in a retry loop with exponential backoff and up to 25% jitter using stdlib `time.sleep` and `random`.
- Only `ModelError` is retried; `UrlFetchError`, `SchemaValidationError`, and other exceptions propagate immediately. Default `max_retries=0` preserves existing behavior exactly.
- Update README usage section and API reference, and add an `Unreleased` CHANGELOG entry.