### PR TITLE
feat: add extract_with_usage to surface model token counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add `extract_async` for async extraction using `Agent.run`.
 - Add `extract_many` and `extract_many_async` for concurrent batch extraction with configurable concurrency and optional exception capture.
 - Add optional `max_retries` and `retry_backoff` keyword arguments to `extract()` for retrying transient `ModelError` failures with exponential backoff and jitter. Default behavior is unchanged (no retries).
+- Add `extract_with_usage` and a `Usage` dataclass that surface model token counts (input, output, total) alongside the extracted output.
 
 ## [0.4.0] - 2026-05-16
 - Accept `http://` URLs in addition to `https://`; previously, plain-HTTP URLs were silently treated as local file paths.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,25 @@ result = extract(
 
 `max_retries` defaults to `0` (single attempt). When set, `extract` retries only on `ModelError` and sleeps `retry_backoff * (2 ** attempt)` seconds (with up to 25% jitter) between attempts. `retry_backoff` defaults to `1.0` second.
 
+### Inspecting token usage
+
+Use `extract_with_usage` when you want token counts alongside the extracted output (for cost tracking, logging, etc.).
+
+```python
+from openextract import extract_with_usage
+
+result, usage = extract_with_usage(
+    schema=PdfInfo,
+    model="openai:gpt-5",
+    input_file="./reports/q4.pdf",
+)
+
+print(result.summary)
+print(f"tokens: {usage.input_tokens} in / {usage.output_tokens} out / {usage.total_tokens} total")
+```
+
+`usage` is a frozen `Usage` dataclass with `input_tokens`, `output_tokens`, and `total_tokens` fields.
+
 
 ### Choosing a model
 

--- a/src/openextract/__init__.py
+++ b/src/openextract/__init__.py
@@ -2,7 +2,14 @@
 openextract - Extract structured data from documents, images, audio, and video using LLMs.
 """
 
-from ._extract import extract, extract_async, extract_many, extract_many_async
+from ._extract import (
+    Usage,
+    extract,
+    extract_async,
+    extract_many,
+    extract_many_async,
+    extract_with_usage,
+)
 from .exceptions import ExtractionError, ModelError, SchemaValidationError, UrlFetchError
 
 __all__ = [
@@ -10,6 +17,8 @@ __all__ = [
     "extract_async",
     "extract_many",
     "extract_many_async",
+    "extract_with_usage",
+    "Usage",
     "ExtractionError",
     "ModelError",
     "SchemaValidationError",

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -5,6 +5,7 @@ import mimetypes
 import random
 import time
 from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import BinaryIO, TypeVar
 
@@ -60,6 +61,15 @@ def _collect_model_error_types() -> tuple[type[BaseException], ...]:
 
 
 _MODEL_ERROR_TYPES: tuple[type[BaseException], ...] = _collect_model_error_types()
+
+
+@dataclass(frozen=True)
+class Usage:
+    """Token usage information for a single extraction call."""
+
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
 
 
 def _get_media_type(file_path: str) -> str:
@@ -144,6 +154,42 @@ def _map_exception(exc: BaseException) -> ExtractionError:
     return ExtractionError(f"Extraction failed: {exc}")
 
 
+def _usage_from_result(result) -> Usage:
+    """Build a ``Usage`` from a pydantic-ai run result."""
+    raw = result.usage()
+    return Usage(
+        input_tokens=getattr(raw, "input_tokens", 0) or 0,
+        output_tokens=getattr(raw, "output_tokens", 0) or 0,
+        total_tokens=getattr(raw, "total_tokens", 0) or 0,
+    )
+
+
+def _run_extraction(
+    schema: type[T],
+    model: str,
+    input_file: str | bytes | BinaryIO,
+    instructions: str | None,
+    media_type: str | None,
+):
+    """Run a single sync extraction and return the raw pydantic-ai result.
+
+    Centralises agent build, exception mapping, and TypeError pass-through so it
+    can be reused by ``extract`` (which discards usage) and
+    ``extract_with_usage`` (which surfaces it).
+    """
+    try:
+        load_dotenv()
+        file_bytes, file_type = _get_media(input_file, media_type=media_type)
+        agent = _build_agent(schema, model, instructions)
+        return agent.run_sync(_build_run_inputs(file_bytes, file_type))
+    except TypeError:
+        raise
+    except ExtractionError:
+        raise
+    except Exception as e:
+        raise _map_exception(e) from e
+
+
 def _extract_once(
     schema: type[T],
     model: str,
@@ -151,19 +197,8 @@ def _extract_once(
     instructions: str | None,
     media_type: str | None,
 ) -> T:
-    """Perform a single sync extraction attempt, classifying exceptions on failure."""
-    try:
-        load_dotenv()
-        file_bytes, file_type = _get_media(input_file, media_type=media_type)
-        agent = _build_agent(schema, model, instructions)
-        result = agent.run_sync(_build_run_inputs(file_bytes, file_type))
-        return result.output
-    except TypeError:
-        raise
-    except ExtractionError:
-        raise
-    except Exception as e:
-        raise _map_exception(e) from e
+    """Perform a single sync extraction attempt; return the schema instance."""
+    return _run_extraction(schema, model, input_file, instructions, media_type).output
 
 
 def extract(
@@ -216,6 +251,23 @@ def extract(
             delay = retry_backoff * (2**attempt) * (1 + random.uniform(0, 0.25))
             time.sleep(delay)
             attempt += 1
+
+
+def extract_with_usage(
+    schema: type[T],
+    model: str,
+    input_file: str | bytes | BinaryIO,
+    instructions: str | None = None,
+    *,
+    media_type: str | None = None,
+) -> tuple[T, Usage]:
+    """Extract structured data and return ``(output, Usage)`` for token accounting.
+
+    Behaves identically to :func:`extract` (without retry) but additionally
+    returns a :class:`Usage` describing the tokens consumed by the model call.
+    """
+    result = _run_extraction(schema, model, input_file, instructions, media_type)
+    return result.output, _usage_from_result(result)
 
 
 async def extract_async(

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -14,10 +14,12 @@ from openextract import (
     ModelError,
     SchemaValidationError,
     UrlFetchError,
+    Usage,
     extract,
     extract_async,
     extract_many,
     extract_many_async,
+    extract_with_usage,
 )
 from openextract._extract import _get_media, _get_media_type
 
@@ -50,6 +52,8 @@ def test_star_import_exposes_only_existing_names():
         "extract_async",
         "extract_many",
         "extract_many_async",
+        "extract_with_usage",
+        "Usage",
         "ExtractionError",
         "ModelError",
         "SchemaValidationError",
@@ -191,7 +195,7 @@ class _Person(BaseModel):
     age: int
 
 
-def _make_agent_mock(mocker, output=None, run_sync_side_effect=None):
+def _make_agent_mock(mocker, output=None, run_sync_side_effect=None, usage=None):
     """Patch openextract._extract.Agent and return (AgentClass, instance, run_sync)."""
     agent_instance = MagicMock()
     if run_sync_side_effect is not None:
@@ -199,6 +203,8 @@ def _make_agent_mock(mocker, output=None, run_sync_side_effect=None):
     else:
         run_result = MagicMock()
         run_result.output = output
+        if usage is not None:
+            run_result.usage.return_value = usage
         agent_instance.run_sync.return_value = run_result
     agent_cls = mocker.patch("openextract._extract.Agent", return_value=agent_instance)
     return agent_cls, agent_instance
@@ -358,6 +364,19 @@ class TestExtract:
             extract(schema=_Person, model="openai:gpt-5", input_file=str(local))
         assert exc_info.value is original
 
+    def test_extract_returns_only_model_instance(self, tmp_path, mocker):
+        """Regression: extract() still returns just the schema instance, not a tuple."""
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hello")
+        expected = _Person(name="Grace", age=42)
+        usage_obj = MagicMock(input_tokens=1, output_tokens=2, total_tokens=3)
+        _make_agent_mock(mocker, output=expected, usage=usage_obj)
+
+        result = extract(schema=_Person, model="openai:gpt-5", input_file=str(local))
+
+        assert result is expected
+        assert not isinstance(result, tuple)
+
 
 # ---------------------------------------------------------------------------
 # extract: input_file polymorphism
@@ -460,6 +479,76 @@ class TestExtractInputs:
 
         with pytest.raises(TypeError, match="input_file must be"):
             extract(schema=_Person, model="openai:gpt-5", input_file=12345)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# extract_with_usage
+# ---------------------------------------------------------------------------
+
+
+class TestExtractWithUsage:
+    def test_returns_output_and_usage_tuple(self, tmp_path, mocker):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hello")
+        expected = _Person(name="Ada", age=36)
+        usage_obj = MagicMock(input_tokens=10, output_tokens=20, total_tokens=30)
+        _make_agent_mock(mocker, output=expected, usage=usage_obj)
+
+        output, usage = extract_with_usage(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_file=str(local),
+            instructions="pull the person",
+        )
+
+        assert output is expected
+        assert usage == Usage(input_tokens=10, output_tokens=20, total_tokens=30)
+
+    def test_missing_usage_fields_default_to_zero(self, tmp_path, mocker):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hello")
+        expected = _Person(name="Linus", age=54)
+
+        class _BareUsage:
+            pass
+
+        _make_agent_mock(mocker, output=expected, usage=_BareUsage())
+
+        _, usage = extract_with_usage(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_file=str(local),
+        )
+
+        assert usage == Usage(input_tokens=0, output_tokens=0, total_tokens=0)
+
+    def test_none_usage_fields_default_to_zero(self, tmp_path, mocker):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hello")
+        expected = _Person(name="Hedy", age=29)
+        usage_obj = MagicMock(input_tokens=None, output_tokens=None, total_tokens=None)
+        _make_agent_mock(mocker, output=expected, usage=usage_obj)
+
+        _, usage = extract_with_usage(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_file=str(local),
+        )
+
+        assert usage == Usage(input_tokens=0, output_tokens=0, total_tokens=0)
+
+    def test_propagates_runtime_error_as_extraction_error(self, tmp_path, mocker):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hello")
+        _make_agent_mock(mocker, run_sync_side_effect=RuntimeError("kaboom"))
+
+        with pytest.raises(ExtractionError, match="Extraction failed: kaboom"):
+            extract_with_usage(schema=_Person, model="openai:gpt-5", input_file=str(local))
+
+    def test_usage_is_frozen_dataclass(self):
+        usage = Usage(input_tokens=1, output_tokens=2, total_tokens=3)
+        with pytest.raises(Exception):  # noqa: B017 - FrozenInstanceError varies by py version
+            usage.input_tokens = 99  # type: ignore[misc]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `extract_with_usage(schema, model, input_file, instructions=None)` that returns `(output, Usage)` so callers can track token consumption alongside the extracted result.
- Introduce a frozen `Usage` dataclass exposing `input_tokens`, `output_tokens`, and `total_tokens`, mapped from `pydantic-ai`'s run usage with safe defaults of `0` for missing or `None` fields.
- Refactor `extract()` to share the agent build and exception-mapping path via a private `_run_extraction` helper, leaving its signature and return type unchanged.
- Export `extract_with_usage` and `Usage` from the package root, with an updated README snippet and `Unreleased` changelog entry.