### PR TITLE
feat: add openextract command-line interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+- Add `openextract` command-line interface for running extractions from the shell.
 - Add `examples/` directory with runnable scripts for invoice, receipt, and meeting-notes extraction.
 
 ## [0.4.0] - 2026-05-16

--- a/README.md
+++ b/README.md
@@ -92,6 +92,27 @@ result = extract(
 
 Set the corresponding provider credentials in your environment (e.g. `OPENAI_API_KEY`). `openextract` loads `.env` automatically.
 
+### Command line
+
+`openextract` ships with a CLI for one-shot extractions from the shell.
+
+```bash
+openextract ./reports/q4.pdf \
+  --schema mypkg.schemas:Invoice \
+  --model openai:gpt-5 \
+  --instructions "Pull totals and line items." \
+  --output json
+```
+
+- `<input_file>` is a positional argument; a local path or `https://` URL.
+- `--schema` is a Python import path of the form `module:ClassName` resolving to a Pydantic model.
+- `--model` is a `pydantic-ai` model identifier.
+- `--instructions` is optional natural-language guidance.
+- `--output` is `json` (default; prints `model_dump_json(indent=2)`) or `repr`.
+
+Exit codes: `0` success, `2` URL fetch error, `3` schema validation error, `4` model error,
+`5` other extraction error, `1` any other failure (including bad `--schema` paths).
+
 ## Examples
 
 Runnable scripts live in the [`examples/`](examples/) directory. Each one takes the input path as the first argument and prints a JSON dump of the validated result:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
     "python-dotenv>=1.2.2",
 ]
 
+[project.scripts]
+openextract = "openextract._cli:main"
+
 [project.urls]
 Homepage = "https://github.com/Mellow-Artificial-Intelligence/openextract"
 Documentation = "https://mellow-artificial-intelligence.github.io/openextract/"

--- a/src/openextract/_cli.py
+++ b/src/openextract/_cli.py
@@ -1,0 +1,113 @@
+"""Command-line interface for openextract."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+from collections.abc import Sequence
+
+from pydantic import BaseModel
+
+from ._extract import extract
+from .exceptions import ExtractionError, ModelError, SchemaValidationError, UrlFetchError
+
+
+def _resolve_schema(schema_path: str) -> type[BaseModel]:
+    """Resolve a ``module:ClassName`` string to a Pydantic ``BaseModel`` subclass."""
+    if ":" not in schema_path:
+        raise ValueError(
+            f"Invalid schema path '{schema_path}'. Expected format 'module:ClassName'."
+        )
+
+    module_part, class_name = schema_path.split(":", 1)
+    if not module_part or not class_name:
+        raise ValueError(
+            f"Invalid schema path '{schema_path}'. Expected format 'module:ClassName'."
+        )
+
+    module = importlib.import_module(module_part)
+    try:
+        cls = getattr(module, class_name)
+    except AttributeError as exc:
+        raise ValueError(f"Class '{class_name}' not found in module '{module_part}'.") from exc
+
+    if not (isinstance(cls, type) and issubclass(cls, BaseModel)):
+        raise ValueError(f"'{schema_path}' does not refer to a Pydantic BaseModel subclass.")
+
+    return cls
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="openextract",
+        description="Extract structured data from a file or URL using an LLM.",
+    )
+    parser.add_argument(
+        "input_file",
+        help="Path or URL of the document, image, audio, or video to extract from.",
+    )
+    parser.add_argument(
+        "--schema",
+        required=True,
+        help="Pydantic model import path in 'module:ClassName' form.",
+    )
+    parser.add_argument(
+        "--model",
+        required=True,
+        help="pydantic-ai model identifier (e.g. 'openai:gpt-5').",
+    )
+    parser.add_argument(
+        "--instructions",
+        default=None,
+        help="Optional natural-language instructions for the model.",
+    )
+    parser.add_argument(
+        "--output",
+        choices=("json", "repr"),
+        default="json",
+        help="Output format: 'json' (default) prints model_dump_json; 'repr' prints repr().",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the openextract CLI. Returns the exit code."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        schema_cls = _resolve_schema(args.schema)
+    except (ImportError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        result = extract(
+            schema=schema_cls,
+            model=args.model,
+            input_file=args.input_file,
+            instructions=args.instructions,
+        )
+    except UrlFetchError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except SchemaValidationError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 3
+    except ModelError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 4
+    except ExtractionError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 5
+
+    if args.output == "json":
+        print(result.model_dump_json(indent=2))
+    else:
+        print(repr(result))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,247 @@
+"""Tests for openextract._cli."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import BaseModel
+
+from openextract import (
+    ExtractionError,
+    ModelError,
+    SchemaValidationError,
+    UrlFetchError,
+)
+from openextract._cli import _resolve_schema, main
+
+
+class _FixtureSchema(BaseModel):
+    name: str
+    age: int
+
+
+class _NotASchema:
+    """Plain class that is not a pydantic BaseModel subclass."""
+
+
+def _patch_extract(mocker, return_value=None, side_effect=None):
+    mock_extract = mocker.patch("openextract._cli.extract")
+    if side_effect is not None:
+        mock_extract.side_effect = side_effect
+    else:
+        mock_extract.return_value = return_value
+    return mock_extract
+
+
+# ---------------------------------------------------------------------------
+# _resolve_schema
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSchema:
+    def test_resolves_valid_schema(self):
+        cls = _resolve_schema("tests.test_cli:_FixtureSchema")
+        assert cls is _FixtureSchema
+
+    def test_missing_colon_raises(self):
+        with pytest.raises(ValueError, match="Expected format"):
+            _resolve_schema("tests.test_cli._FixtureSchema")
+
+    def test_empty_module_raises(self):
+        with pytest.raises(ValueError, match="Expected format"):
+            _resolve_schema(":_FixtureSchema")
+
+    def test_empty_class_raises(self):
+        with pytest.raises(ValueError, match="Expected format"):
+            _resolve_schema("tests.test_cli:")
+
+    def test_missing_class_raises(self):
+        with pytest.raises(ValueError, match="not found in module"):
+            _resolve_schema("tests.test_cli:DoesNotExist")
+
+    def test_non_basemodel_raises(self):
+        with pytest.raises(ValueError, match="does not refer to a Pydantic BaseModel"):
+            _resolve_schema("tests.test_cli:_NotASchema")
+
+    def test_bad_module_raises_import_error(self):
+        with pytest.raises(ImportError):
+            _resolve_schema("definitely_not_a_real_module_xyz:Thing")
+
+
+# ---------------------------------------------------------------------------
+# argparse behavior
+# ---------------------------------------------------------------------------
+
+
+class TestArgparse:
+    def test_missing_required_args_exits_nonzero(self, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            main([])
+        assert exc_info.value.code != 0
+        captured = capsys.readouterr()
+        assert "usage" in captured.err.lower()
+
+    def test_missing_schema_exits_nonzero(self, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            main(["input.txt", "--model", "openai:gpt-5"])
+        assert exc_info.value.code != 0
+        captured = capsys.readouterr()
+        assert "schema" in captured.err.lower()
+
+    def test_missing_model_exits_nonzero(self, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            main(["input.txt", "--schema", "tests.test_cli:_FixtureSchema"])
+        assert exc_info.value.code != 0
+        captured = capsys.readouterr()
+        assert "model" in captured.err.lower()
+
+    def test_invalid_output_choice_exits_nonzero(self, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            main(
+                [
+                    "input.txt",
+                    "--schema",
+                    "tests.test_cli:_FixtureSchema",
+                    "--model",
+                    "openai:gpt-5",
+                    "--output",
+                    "yaml",
+                ]
+            )
+        assert exc_info.value.code != 0
+        captured = capsys.readouterr()
+        assert "output" in captured.err.lower()
+
+
+# ---------------------------------------------------------------------------
+# main success paths
+# ---------------------------------------------------------------------------
+
+
+class TestMainSuccess:
+    def test_json_output_default(self, mocker, capsys):
+        fake = MagicMock()
+        fake.model_dump_json.return_value = '{\n  "name": "Ada",\n  "age": 36\n}'
+        mock_extract = _patch_extract(mocker, return_value=fake)
+
+        exit_code = main(
+            [
+                "input.txt",
+                "--schema",
+                "tests.test_cli:_FixtureSchema",
+                "--model",
+                "openai:gpt-5",
+                "--instructions",
+                "find the person",
+            ]
+        )
+
+        assert exit_code == 0
+        fake.model_dump_json.assert_called_once_with(indent=2)
+        mock_extract.assert_called_once_with(
+            schema=_FixtureSchema,
+            model="openai:gpt-5",
+            input_file="input.txt",
+            instructions="find the person",
+        )
+        captured = capsys.readouterr()
+        assert '"name": "Ada"' in captured.out
+
+    def test_repr_output(self, mocker, capsys):
+        fake = MagicMock()
+        fake.__repr__ = lambda self: "_FixtureSchema(name='Linus', age=54)"
+        _patch_extract(mocker, return_value=fake)
+
+        exit_code = main(
+            [
+                "input.txt",
+                "--schema",
+                "tests.test_cli:_FixtureSchema",
+                "--model",
+                "openai:gpt-5",
+                "--output",
+                "repr",
+            ]
+        )
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "_FixtureSchema(name='Linus', age=54)" in captured.out
+
+    def test_instructions_default_to_none(self, mocker):
+        fake = MagicMock()
+        fake.model_dump_json.return_value = "{}"
+        mock_extract = _patch_extract(mocker, return_value=fake)
+
+        exit_code = main(
+            [
+                "input.txt",
+                "--schema",
+                "tests.test_cli:_FixtureSchema",
+                "--model",
+                "openai:gpt-5",
+            ]
+        )
+
+        assert exit_code == 0
+        assert mock_extract.call_args.kwargs["instructions"] is None
+
+
+# ---------------------------------------------------------------------------
+# main error paths / exit codes
+# ---------------------------------------------------------------------------
+
+
+class TestMainErrorCodes:
+    def _invoke(self, mocker, exc):
+        _patch_extract(mocker, side_effect=exc)
+        return main(
+            [
+                "input.txt",
+                "--schema",
+                "tests.test_cli:_FixtureSchema",
+                "--model",
+                "openai:gpt-5",
+            ]
+        )
+
+    def test_url_fetch_error_returns_2(self, mocker, capsys):
+        assert self._invoke(mocker, UrlFetchError("404")) == 2
+        assert "404" in capsys.readouterr().err
+
+    def test_schema_validation_error_returns_3(self, mocker, capsys):
+        assert self._invoke(mocker, SchemaValidationError("bad shape")) == 3
+        assert "bad shape" in capsys.readouterr().err
+
+    def test_model_error_returns_4(self, mocker, capsys):
+        assert self._invoke(mocker, ModelError("upstream")) == 4
+        assert "upstream" in capsys.readouterr().err
+
+    def test_extraction_error_returns_5(self, mocker, capsys):
+        assert self._invoke(mocker, ExtractionError("misc")) == 5
+        assert "misc" in capsys.readouterr().err
+
+    def test_bad_schema_module_returns_1(self, capsys):
+        exit_code = main(
+            [
+                "input.txt",
+                "--schema",
+                "definitely_not_a_real_module_xyz:Thing",
+                "--model",
+                "openai:gpt-5",
+            ]
+        )
+        assert exit_code == 1
+        assert "error" in capsys.readouterr().err.lower()
+
+    def test_schema_not_basemodel_returns_1(self, capsys):
+        exit_code = main(
+            [
+                "input.txt",
+                "--schema",
+                "tests.test_cli:_NotASchema",
+                "--model",
+                "openai:gpt-5",
+            ]
+        )
+        assert exit_code == 1
+        assert "BaseModel" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- Adds an `openextract` console script (`src/openextract/_cli.py`) that wraps `extract()` with argparse, resolves Pydantic schemas from `module:ClassName` import paths, and prints results as JSON (default) or repr.
- Maps each extraction error class to a distinct exit code (`2` URL, `3` schema, `4` model, `5` other extraction, `1` everything else, including bad `--schema` paths).
- Wires up the `[project.scripts]` entry point in `pyproject.toml` and documents the new CLI in `README.md` and `CHANGELOG.md` (under `[Unreleased]`, no version bump).