### PR TITLE
release: bump to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
-- Add `openextract` command-line interface for running extractions from the shell.
-- Add `examples/` directory with runnable scripts for invoice, receipt, and meeting-notes extraction.
-- Replace the substring-based exception classifier in `extract()` with typed provider-error matching against a tuple of known model-error base classes (`pydantic_ai.exceptions.ModelAPIError`, `openai.APIError`, `google.genai.errors.APIError`). Behavior change: an arbitrary exception whose message merely mentions "model" is no longer promoted to `ModelError`; it is now wrapped as `ExtractionError` unless the exception type is a subclass of a known provider error.
-- Accept raw `bytes` or any binary file-like object as `extract`'s `input_file`.
-- Add keyword-only `media_type` parameter for explicit MIME typing; required for `bytes` and file-like inputs, and overrides the guess for `str` paths and URLs.
+## [0.5.0] - 2026-05-16
 - Add `extract_async` for async extraction using `Agent.run`.
 - Add `extract_many` and `extract_many_async` for concurrent batch extraction with configurable concurrency and optional exception capture.
+- Accept raw `bytes` or any binary file-like object as `extract`'s `input_file`; new keyword-only `media_type` parameter for explicit MIME typing (required for `bytes`/file-like inputs, optional override for `str`).
 - Add optional `max_retries` and `retry_backoff` keyword arguments to `extract()` for retrying transient `ModelError` failures with exponential backoff and jitter. Default behavior is unchanged (no retries).
 - Add `extract_with_usage` and a `Usage` dataclass that surface model token counts (input, output, total) alongside the extracted output.
+- Add `openextract` command-line interface (`openextract <file> --schema module:Class --model openai:gpt-5`) with structured exit codes.
+- Add `examples/` directory with runnable scripts for invoice, receipt, and meeting-notes extraction.
+- Replace the substring-based exception classifier in `extract()` with typed provider-error matching against `pydantic_ai.exceptions.ModelAPIError`, `openai.APIError`, and `google.genai.errors.APIError`. Behavior change: an arbitrary exception whose message merely mentions "model" is no longer promoted to `ModelError`; it is now wrapped as `ExtractionError` unless the exception type is a subclass of a known provider error.
 
 ## [0.4.0] - 2026-05-16
 - Accept `http://` URLs in addition to `https://`; previously, plain-HTTP URLs were silently treated as local file paths.
@@ -42,7 +41,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.1.1] - 2025-09-10
 - Merge pull request #12 from Mellow-Artificial-Intelligence/new-release.
 
-[Unreleased]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.3.1...v0.3.2
 [0.2.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.1.4...v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openextract"
-version = "0.4.0"
+version = "0.5.0"
 description = "Extract structured data from documents, images, audio, and video using LLMs"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -613,7 +613,7 @@ wheels = [
 
 [[package]]
 name = "openextract"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Promotes the `## [Unreleased]` entries to a tagged `0.5.0` release and bumps `pyproject.toml`. The Release workflow on `main` will tag `v0.5.0`, build, publish to PyPI, and cut the GitHub Release on merge.

### 0.5.0 includes (merged via PRs #60-#66)
- **Async + batch** (#63) — `extract_async`, `extract_many`, `extract_many_async` with concurrency limit and `return_exceptions` (gather-style).
- **Bytes / file-like input** (#61) — `extract` now accepts `str | bytes | BinaryIO`; new keyword-only `media_type` (required for `bytes`/file-like, optional override for `str`).
- **Retry with backoff** (#64) — `max_retries` / `retry_backoff` on `extract()`; retries only `ModelError`, jittered exponential backoff.
- **Usage / cost** (#65) — `extract_with_usage()` returns `(output, Usage)`; new frozen `Usage` dataclass.
- **CLI** (#66) — `openextract <file> --schema module:Class --model openai:gpt-5` with structured exit codes.
- **Examples** (#60) — runnable `examples/invoice_extraction.py`, `receipt_extraction.py`, `meeting_notes.py`.
- **Exception classifier refactor** (#62) — replace the `"api" / "model"` substring heuristic with typed provider-error matching (`pydantic_ai.exceptions.ModelAPIError`, `openai.APIError`, `google.genai.errors.APIError`). Behavior change: an exception whose message merely mentions "model" is no longer auto-promoted to `ModelError`.

83 tests, 100% line + branch coverage, lint clean.