### PR TITLE
docs: refresh landing page for 0.5.0

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -96,12 +96,12 @@
         <div class="max-w-3xl mx-auto px-4 sm:px-6 py-16 sm:py-24 text-center">
 
           <!-- Badge -->
-          <div class="animate-slide-up opacity-0 inline-flex items-center gap-2.5 px-3 py-1.5 border border-black/10 bg-white text-xs mb-8">
+          <a href="#whats-new" class="animate-slide-up opacity-0 inline-flex items-center gap-2.5 px-3 py-1.5 border border-black/10 bg-white text-xs mb-8 hover:border-black/30 transition-colors">
             <span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>
-            <span class="font-mono text-black/50">v0.3.1</span>
+            <span class="font-mono text-black/50">v0.5.0</span>
             <span class="text-black/30">|</span>
-            <span class="text-black/50">Structured Extraction</span>
-          </div>
+            <span class="text-black/50">async, batch, retry, CLI</span>
+          </a>
 
           <!-- Headline -->
           <h1 class="animate-slide-up opacity-0 [animation-delay:100ms] text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight mb-4 sm:mb-6 bg-gradient-to-b from-black to-black/50 bg-clip-text text-transparent">
@@ -141,7 +141,7 @@
 
 <span class="text-black/70">result</span> <span class="text-black/40">=</span> <span class="text-black/70">extract</span>(
     <span class="text-black/40">schema=</span><span class="text-black/70">Invoice</span>,
-    <span class="text-black/40">model=</span><span class="text-emerald-600">"openai:gpt-5.4"</span>,
+    <span class="text-black/40">model=</span><span class="text-emerald-600">"openai:gpt-5"</span>,
     <span class="text-black/40">input_file=</span><span class="text-emerald-600">"https://example.com/doc.pdf"</span>,
     <span class="text-black/40">instructions=</span><span class="text-emerald-600">"Extract invoice data"</span>,
 )</code></pre>
@@ -188,7 +188,7 @@
               </div>
               <h3 class="font-mono text-sm font-medium text-black/80 mb-2">Any LLM</h3>
               <p class="text-sm text-black/40 leading-relaxed">
-                OpenAI, Anthropic, Google. One model string, zero config.
+                OpenAI, Google, and Ollama out of the box. One model string, zero config.
               </p>
             </div>
 
@@ -200,6 +200,136 @@
               <p class="text-sm text-black/40 leading-relaxed">
                 Pydantic schemas ensure validated, typed output every time.
               </p>
+            </div>
+
+          </div>
+        </div>
+      </section>
+
+      <!-- What's new in 0.5.0 -->
+      <section id="whats-new" class="py-16 sm:py-24 border-t border-black/5 scroll-mt-14">
+        <div class="max-w-5xl mx-auto px-4 sm:px-6">
+          <div class="flex items-baseline justify-between mb-8 sm:mb-10 flex-wrap gap-3">
+            <div>
+              <p class="font-mono text-[11px] text-black/30 uppercase tracking-wider mb-2">What&rsquo;s new</p>
+              <h2 class="text-2xl sm:text-3xl font-bold text-black/90">v0.5.0</h2>
+            </div>
+            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/CHANGELOG.md" class="font-mono text-xs text-black/40 hover:text-black/70 transition-colors inline-flex items-center gap-1.5">
+              Full changelog <i data-lucide="arrow-up-right" class="w-3 h-3"></i>
+            </a>
+          </div>
+
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4">
+
+            <div class="p-5 border border-black/10 bg-white">
+              <div class="flex items-center gap-3 mb-3">
+                <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
+                  <i data-lucide="git-branch" class="w-4 h-4 text-black/50"></i>
+                </div>
+                <span class="font-mono text-[10px] text-black/30 uppercase tracking-wider">Concurrency</span>
+              </div>
+              <h3 class="font-mono text-sm font-medium text-black/80 mb-2">Async &amp; batch</h3>
+              <p class="text-sm text-black/40 leading-relaxed mb-3">
+                <code class="font-mono text-black/60 text-xs">extract_async</code>, <code class="font-mono text-black/60 text-xs">extract_many</code>, and <code class="font-mono text-black/60 text-xs">extract_many_async</code> for concurrent runs with an explicit limit.
+              </p>
+              <pre class="text-[11px] font-mono leading-relaxed text-black/60 bg-black/5 p-2.5 overflow-x-auto"><code>results = extract_many(
+    schema=Invoice,
+    model=<span class="text-emerald-600">"openai:gpt-5"</span>,
+    input_files=paths,
+    max_concurrency=<span class="text-emerald-600">5</span>,
+)</code></pre>
+            </div>
+
+            <div class="p-5 border border-black/10 bg-white">
+              <div class="flex items-center gap-3 mb-3">
+                <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
+                  <i data-lucide="file-input" class="w-4 h-4 text-black/50"></i>
+                </div>
+                <span class="font-mono text-[10px] text-black/30 uppercase tracking-wider">Inputs</span>
+              </div>
+              <h3 class="font-mono text-sm font-medium text-black/80 mb-2">Bytes &amp; file-like</h3>
+              <p class="text-sm text-black/40 leading-relaxed mb-3">
+                Pass raw <code class="font-mono text-black/60 text-xs">bytes</code> or any <code class="font-mono text-black/60 text-xs">BinaryIO</code>. No temp file dance.
+              </p>
+              <pre class="text-[11px] font-mono leading-relaxed text-black/60 bg-black/5 p-2.5 overflow-x-auto"><code>extract(
+    schema=Invoice,
+    model=<span class="text-emerald-600">"openai:gpt-5"</span>,
+    input_file=pdf_bytes,
+    media_type=<span class="text-emerald-600">"application/pdf"</span>,
+)</code></pre>
+            </div>
+
+            <div class="p-5 border border-black/10 bg-white">
+              <div class="flex items-center gap-3 mb-3">
+                <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
+                  <i data-lucide="refresh-cw" class="w-4 h-4 text-black/50"></i>
+                </div>
+                <span class="font-mono text-[10px] text-black/30 uppercase tracking-wider">Reliability</span>
+              </div>
+              <h3 class="font-mono text-sm font-medium text-black/80 mb-2">Retry with backoff</h3>
+              <p class="text-sm text-black/40 leading-relaxed mb-3">
+                Opt-in retries on <code class="font-mono text-black/60 text-xs">ModelError</code> with jittered exponential backoff.
+              </p>
+              <pre class="text-[11px] font-mono leading-relaxed text-black/60 bg-black/5 p-2.5 overflow-x-auto"><code>extract(
+    schema=Invoice,
+    model=<span class="text-emerald-600">"openai:gpt-5"</span>,
+    input_file=path,
+    max_retries=<span class="text-emerald-600">3</span>,
+)</code></pre>
+            </div>
+
+            <div class="p-5 border border-black/10 bg-white">
+              <div class="flex items-center gap-3 mb-3">
+                <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
+                  <i data-lucide="activity" class="w-4 h-4 text-black/50"></i>
+                </div>
+                <span class="font-mono text-[10px] text-black/30 uppercase tracking-wider">Observability</span>
+              </div>
+              <h3 class="font-mono text-sm font-medium text-black/80 mb-2">Token usage</h3>
+              <p class="text-sm text-black/40 leading-relaxed mb-3">
+                <code class="font-mono text-black/60 text-xs">extract_with_usage</code> returns input, output, and total token counts.
+              </p>
+              <pre class="text-[11px] font-mono leading-relaxed text-black/60 bg-black/5 p-2.5 overflow-x-auto"><code>output, usage = extract_with_usage(
+    schema=Invoice,
+    model=<span class="text-emerald-600">"openai:gpt-5"</span>,
+    input_file=path,
+)
+<span class="text-black/40">print(usage.total_tokens)</span></code></pre>
+            </div>
+
+            <div class="p-5 border border-black/10 bg-white">
+              <div class="flex items-center gap-3 mb-3">
+                <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
+                  <i data-lucide="terminal" class="w-4 h-4 text-black/50"></i>
+                </div>
+                <span class="font-mono text-[10px] text-black/30 uppercase tracking-wider">CLI</span>
+              </div>
+              <h3 class="font-mono text-sm font-medium text-black/80 mb-2">Shell-friendly</h3>
+              <p class="text-sm text-black/40 leading-relaxed mb-3">
+                Drive extractions from the shell with structured exit codes.
+              </p>
+              <pre class="text-[11px] font-mono leading-relaxed text-black/60 bg-black/5 p-2.5 overflow-x-auto"><code><span class="text-black/40">$</span> openextract doc.pdf \
+    --schema mypkg:Invoice \
+    --model <span class="text-emerald-600">openai:gpt-5</span></code></pre>
+            </div>
+
+            <div class="p-5 border border-black/10 bg-white">
+              <div class="flex items-center gap-3 mb-3">
+                <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
+                  <i data-lucide="shield-alert" class="w-4 h-4 text-black/50"></i>
+                </div>
+                <span class="font-mono text-[10px] text-black/30 uppercase tracking-wider">Errors</span>
+              </div>
+              <h3 class="font-mono text-sm font-medium text-black/80 mb-2">Typed classifier</h3>
+              <p class="text-sm text-black/40 leading-relaxed mb-3">
+                Provider errors (<code class="font-mono text-black/60 text-xs">openai.APIError</code>, Google, pydantic-ai) become <code class="font-mono text-black/60 text-xs">ModelError</code> by type, not substring.
+              </p>
+              <pre class="text-[11px] font-mono leading-relaxed text-black/60 bg-black/5 p-2.5 overflow-x-auto"><code><span class="text-black/40">try:</span>
+    extract(...)
+<span class="text-black/40">except</span> ModelError:
+    <span class="text-black/40">...  # provider issue</span>
+<span class="text-black/40">except</span> SchemaValidationError:
+    <span class="text-black/40">...  # bad shape</span></code></pre>
             </div>
 
           </div>
@@ -261,7 +391,7 @@
 
 <span class="text-black/70">result</span> <span class="text-black/40">=</span> <span class="text-black/70">extract</span>(
     <span class="text-black/40">schema=</span><span class="text-black/70">Report</span>,
-    <span class="text-black/40">model=</span><span class="text-emerald-600">"openai:gpt-5.2"</span>,
+    <span class="text-black/40">model=</span><span class="text-emerald-600">"openai:gpt-5"</span>,
     <span class="text-black/40">input_file=</span><span class="text-emerald-600">"https://example.com/report.pdf"</span>,
     <span class="text-black/40">instructions=</span><span class="text-emerald-600">"Extract findings"</span>,
 )</code></pre>
@@ -299,7 +429,7 @@
     <!-- Footer -->
     <footer class="py-6 sm:py-8 border-t border-black/5">
       <div class="max-w-5xl mx-auto px-4 sm:px-6 flex flex-col sm:flex-row justify-between items-center gap-4">
-        <span class="font-mono text-xs text-black/30">&copy; 2025 openextract. MIT License.</span>
+        <span class="font-mono text-xs text-black/30">&copy; 2026 openextract. MIT License.</span>
         <div class="flex gap-6">
           <a href="https://github.com/Mellow-Artificial-Intelligence/openextract" class="font-mono text-xs text-black/30 hover:text-black/60 transition-colors">GitHub</a>
           <a href="https://pypi.org/project/openextract/" class="font-mono text-xs text-black/30 hover:text-black/60 transition-colors">PyPI</a>


### PR DESCRIPTION
## Summary

- Bump the version badge to `v0.5.0` and turn it into an anchor link to the new "What's new" section.
- Add a "What's new in v0.5.0" section with six cards (async + batch, bytes/file-like input, retry with backoff, token usage, CLI, typed exception classifier), each with a small code snippet that mirrors the README's examples.
- Fix the Any-LLM card text (was "OpenAI, Anthropic, Google" but the package actually ships extras for OpenAI, Google, and Ollama).
- Replace fictional model strings (`openai:gpt-5.4`, `openai:gpt-5.2`) with `openai:gpt-5` in the hero and how-it-works code samples.
- Bump the footer copyright to 2026.

GitHub Pages re-deploys from `main` via the existing Pages workflow on merge.