### PR TITLE
feat: add anthropic provider support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+- Add Anthropic provider support (extra `pydantic-ai-slim[anthropic]`; provider errors wrapped as `ModelError`).
+
 ## [0.5.0] - 2026-05-16
 - Add `extract_async` for async extraction using `Agent.run`.
 - Add `extract_many` and `extract_many_async` for concurrent batch extraction with configurable concurrency and optional exception capture.

--- a/README.md
+++ b/README.md
@@ -125,11 +125,12 @@ print(f"tokens: {usage.input_tokens} in / {usage.output_tokens} out / {usage.tot
 
 `model` follows the `pydantic-ai` provider prefix convention:
 
-| Provider | Example identifier         |
-| -------- | -------------------------- |
-| OpenAI   | `openai:gpt-5`             |
-| Google   | `google-gla:gemini-2.5-pro`|
-| Ollama   | `ollama:llama3`            |
+| Provider  | Example identifier          |
+| --------- | --------------------------- |
+| OpenAI    | `openai:gpt-5`              |
+| Anthropic | `anthropic:claude-sonnet-4` |
+| Google    | `google-gla:gemini-2.5-pro` |
+| Ollama    | `ollama:llama3`             |
 
 Set the corresponding provider credentials in your environment (e.g. `OPENAI_API_KEY`). `openextract` loads `.env` automatically.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "pydantic>=2.12.5",
-    "pydantic-ai-slim[google,logfire,openai]>=1.37.0",
+    "pydantic-ai-slim[anthropic,google,logfire,openai]>=1.37.0",
     "python-dotenv>=1.2.2",
 ]
 

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -51,6 +51,13 @@ def _collect_model_error_types() -> tuple[type[BaseException], ...]:
         pass
 
     try:
+        from anthropic import APIError as AnthropicAPIError
+
+        error_types.append(AnthropicAPIError)
+    except ImportError:  # pragma: no cover - anthropic extra is installed
+        pass
+
+    try:
         from google.genai.errors import APIError as GoogleAPIError
 
         error_types.append(GoogleAPIError)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -320,6 +320,21 @@ class TestExtract:
         with pytest.raises(ModelError, match="Model API error"):
             extract(schema=_Person, model="openai:gpt-5", input_file=str(local))
 
+    def test_anthropic_api_error_is_wrapped_as_model_error(self, tmp_path, mocker):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hello")
+        from anthropic import APIError as AnthropicAPIError
+
+        class _FakeAnthropicError(AnthropicAPIError):
+            def __init__(self, message: str):
+                # Bypass AnthropicAPIError.__init__ to avoid constructing request/body objects.
+                Exception.__init__(self, message)
+
+        _make_agent_mock(mocker, run_sync_side_effect=_FakeAnthropicError("rate limited"))
+
+        with pytest.raises(ModelError, match="Model API error"):
+            extract(schema=_Person, model="anthropic:claude-sonnet-4", input_file=str(local))
+
     def test_message_mentioning_model_is_wrapped_as_extraction_error(self, tmp_path, mocker):
         local = tmp_path / "input.txt"
         local.write_bytes(b"hello")

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.102.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/47/cb2a71f70431fb09af4db83e3ea89eb2dd8e0e348d27af53ed32e6c599dd/anthropic-0.102.0.tar.gz", hash = "sha256:96f747cad11886c4ae12d4080131b94eebd68b202bd2190fe27959031bb1fa9c", size = 763697, upload-time = "2026-05-13T18:12:41.624Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/75/0f6c603594876413bc858a00e7cc0d80a0cc14edf5c7b959a3ea6ec45e44/anthropic-0.102.0-py3-none-any.whl", hash = "sha256:ab96540bbd4b0f36564252d955a86f8abbe4f00944a24bc9931acc9b139bab6f", size = 763070, upload-time = "2026-05-13T18:12:43.474Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -319,6 +338,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -617,7 +645,7 @@ version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
-    { name = "pydantic-ai-slim", extra = ["google", "logfire", "openai"] },
+    { name = "pydantic-ai-slim", extra = ["anthropic", "google", "logfire", "openai"] },
     { name = "python-dotenv" },
 ]
 
@@ -633,7 +661,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5" },
-    { name = "pydantic-ai-slim", extras = ["google", "logfire", "openai"], specifier = ">=1.37.0" },
+    { name = "pydantic-ai-slim", extras = ["anthropic", "google", "logfire", "openai"], specifier = ">=1.37.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
 ]
 
@@ -865,6 +893,9 @@ wheels = [
 ]
 
 [package.optional-dependencies]
+anthropic = [
+    { name = "anthropic" },
+]
 google = [
     { name = "google-genai" },
 ]


### PR DESCRIPTION
## Summary
- Extend `pydantic-ai-slim` extras with `anthropic` so the provider ships as a first-class option.
- Classify `anthropic.APIError` in `_collect_model_error_types()` so provider failures surface as `ModelError`.
- Document the `anthropic:claude-sonnet-4` identifier in the README provider table and record the change in the changelog.