### PR TITLE
feat: add Hugging Face provider support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add AWS Bedrock provider support (extra `pydantic-ai-slim[bedrock]`; `botocore.exceptions.ClientError` wrapped as `ModelError`).
 - Add xAI (Grok) provider support (extra `pydantic-ai-slim[xai]`).
 - Add Cohere provider support (extra `pydantic-ai-slim[cohere]`; `cohere.core.api_error.ApiError` wrapped as `ModelError`).
+- Add Hugging Face provider support (extra `pydantic-ai-slim[huggingface]`; `huggingface_hub.errors.HfHubHTTPError` wrapped as `ModelError`).
 
 ## [0.5.0] - 2026-05-16
 - Add `extract_async` for async extraction using `Agent.run`.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 - **Type-safe output.** Define your shape with Pydantic; get back a validated instance.
 - **One function, many modalities.** Documents (PDF, DOCX), images, audio, and video.
 - **Local files or URLs.** Pass a path or an `https://` URL &mdash; `openextract` handles fetching.
-- **Bring your own model.** OpenAI, Google, Ollama, and Cohere supported out of the box via [`pydantic-ai`](https://github.com/pydantic/pydantic-ai).
+- **Bring your own model.** OpenAI, Anthropic, Google, AWS Bedrock, xAI, Cohere, Hugging Face, and Ollama supported out of the box via [`pydantic-ai`](https://github.com/pydantic/pydantic-ai).
 - **Explicit error handling.** Distinct exceptions for URL fetch, schema validation, and model errors.
 - **100% test coverage**, enforced in CI.
 
@@ -125,15 +125,16 @@ print(f"tokens: {usage.input_tokens} in / {usage.output_tokens} out / {usage.tot
 
 `model` follows the `pydantic-ai` provider prefix convention:
 
-| Provider    | Example identifier                                  |
-| ----------- | --------------------------------------------------- |
-| OpenAI      | `openai:gpt-5`                                      |
-| Anthropic   | `anthropic:claude-sonnet-4`                         |
-| Google      | `google-gla:gemini-2.5-pro`                         |
-| AWS Bedrock | `bedrock:anthropic.claude-sonnet-4-20250514-v1:0`   |
-| xAI         | `xai:grok-4`                                        |
-| Cohere      | `cohere:command-r-plus`                             |
-| Ollama      | `ollama:llama3`                                     |
+| Provider     | Example identifier                                  |
+| ------------ | --------------------------------------------------- |
+| OpenAI       | `openai:gpt-5`                                      |
+| Anthropic    | `anthropic:claude-sonnet-4`                         |
+| Google       | `google-gla:gemini-2.5-pro`                         |
+| AWS Bedrock  | `bedrock:anthropic.claude-sonnet-4-20250514-v1:0`   |
+| xAI          | `xai:grok-4`                                        |
+| Cohere       | `cohere:command-r-plus`                             |
+| Hugging Face | `huggingface:meta-llama/Llama-3.3-70B-Instruct`     |
+| Ollama       | `ollama:llama3`                                     |
 
 Set the corresponding provider credentials in your environment (e.g. `OPENAI_API_KEY`). `openextract` loads `.env` automatically.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "pydantic>=2.12.5",
-    "pydantic-ai-slim[anthropic,bedrock,cohere,google,logfire,openai,xai]>=1.37.0",
+    "pydantic-ai-slim[anthropic,bedrock,cohere,google,huggingface,logfire,openai,xai]>=1.37.0",
     "python-dotenv>=1.2.2",
 ]
 

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -78,6 +78,13 @@ def _collect_model_error_types() -> tuple[type[BaseException], ...]:
     except ImportError:  # pragma: no cover - cohere extra is installed
         pass
 
+    try:
+        from huggingface_hub.errors import HfHubHTTPError
+
+        error_types.append(HfHubHTTPError)
+    except ImportError:  # pragma: no cover - huggingface extra is installed
+        pass
+
     return tuple(error_types)
 
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -371,6 +371,26 @@ class TestExtract:
         with pytest.raises(ModelError, match="Model API error"):
             extract(schema=_Person, model="cohere:command-r-plus", input_file=str(local))
 
+    def test_huggingface_http_error_is_wrapped_as_model_error(self, tmp_path, mocker):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hello")
+        from huggingface_hub.errors import HfHubHTTPError
+
+        class _FakeHfHubHTTPError(HfHubHTTPError):
+            def __init__(self, message: str):
+                # Bypass HfHubHTTPError.__init__ to avoid constructing a Response object.
+                Exception.__init__(self, message)
+
+        _make_agent_mock(mocker, run_sync_side_effect=_FakeHfHubHTTPError("hf upstream down"))
+
+        with pytest.raises(ModelError, match="Model API error"):
+            extract(
+                schema=_Person,
+                model="huggingface:meta-llama/Llama-3.3-70B-Instruct",
+                input_file=str(local),
+            )
+
+
     def test_message_mentioning_model_is_wrapped_as_extraction_error(self, tmp_path, mocker):
         local = tmp_path / "input.txt"
         local.write_bytes(b"hello")

--- a/uv.lock
+++ b/uv.lock
@@ -1176,7 +1176,7 @@ version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
-    { name = "pydantic-ai-slim", extra = ["anthropic", "bedrock", "cohere", "google", "logfire", "openai", "xai"] },
+    { name = "pydantic-ai-slim", extra = ["anthropic", "bedrock", "cohere", "google", "huggingface", "logfire", "openai", "xai"] },
     { name = "python-dotenv" },
 ]
 
@@ -1192,7 +1192,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5" },
-    { name = "pydantic-ai-slim", extras = ["anthropic", "bedrock", "cohere", "google", "logfire", "openai", "xai"], specifier = ">=1.37.0" },
+    { name = "pydantic-ai-slim", extras = ["anthropic", "bedrock", "cohere", "google", "huggingface", "logfire", "openai", "xai"], specifier = ">=1.37.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
 ]
 
@@ -1529,6 +1529,9 @@ cohere = [
 ]
 google = [
     { name = "google-genai" },
+]
+huggingface = [
+    { name = "huggingface-hub" },
 ]
 logfire = [
     { name = "logfire", extra = ["httpx"] },


### PR DESCRIPTION
## Summary
- Extend the `pydantic-ai-slim` install extras with `huggingface` so the Hugging Face provider ships out of the box.
- Recognise `huggingface_hub.errors.HfHubHTTPError` in `_collect_model_error_types()` so Hugging Face upstream failures surface as `ModelError`.
- Document the provider in the README (features list and provider table with a `huggingface:meta-llama/Llama-3.3-70B-Instruct` example) and note the addition under `## [Unreleased]` in the changelog.