### PR TITLE
feat: add Groq provider support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add xAI (Grok) provider support (extra `pydantic-ai-slim[xai]`).
 - Add Cohere provider support (extra `pydantic-ai-slim[cohere]`; `cohere.core.api_error.ApiError` wrapped as `ModelError`).
 - Add Hugging Face provider support (extra `pydantic-ai-slim[huggingface]`; `huggingface_hub.errors.HfHubHTTPError` wrapped as `ModelError`).
+- Add Groq provider support (extra `pydantic-ai-slim[groq]`; `groq.APIError` wrapped as `ModelError`).
 
 ## [0.5.0] - 2026-05-16
 - Add `extract_async` for async extraction using `Agent.run`.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 - **Type-safe output.** Define your shape with Pydantic; get back a validated instance.
 - **One function, many modalities.** Documents (PDF, DOCX), images, audio, and video.
 - **Local files or URLs.** Pass a path or an `https://` URL &mdash; `openextract` handles fetching.
-- **Bring your own model.** OpenAI, Anthropic, Google, AWS Bedrock, xAI, Cohere, Hugging Face, and Ollama supported out of the box via [`pydantic-ai`](https://github.com/pydantic/pydantic-ai).
+- **Bring your own model.** OpenAI, Anthropic, Google, AWS Bedrock, xAI, Cohere, Hugging Face, Groq, and Ollama supported out of the box via [`pydantic-ai`](https://github.com/pydantic/pydantic-ai).
 - **Explicit error handling.** Distinct exceptions for URL fetch, schema validation, and model errors.
 - **100% test coverage**, enforced in CI.
 
@@ -134,6 +134,7 @@ print(f"tokens: {usage.input_tokens} in / {usage.output_tokens} out / {usage.tot
 | xAI          | `xai:grok-4`                                        |
 | Cohere       | `cohere:command-r-plus`                             |
 | Hugging Face | `huggingface:meta-llama/Llama-3.3-70B-Instruct`     |
+| Groq         | `groq:llama-3.3-70b-versatile`                      |
 | Ollama       | `ollama:llama3`                                     |
 
 Set the corresponding provider credentials in your environment (e.g. `OPENAI_API_KEY`). `openextract` loads `.env` automatically.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "pydantic>=2.12.5",
-    "pydantic-ai-slim[anthropic,bedrock,cohere,google,huggingface,logfire,openai,xai]>=1.37.0",
+    "pydantic-ai-slim[anthropic,bedrock,cohere,google,groq,huggingface,logfire,openai,xai]>=1.37.0",
     "python-dotenv>=1.2.2",
 ]
 

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -85,6 +85,13 @@ def _collect_model_error_types() -> tuple[type[BaseException], ...]:
     except ImportError:  # pragma: no cover - huggingface extra is installed
         pass
 
+    try:
+        from groq import APIError as GroqAPIError
+
+        error_types.append(GroqAPIError)
+    except ImportError:  # pragma: no cover - groq extra is installed
+        pass
+
     return tuple(error_types)
 
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -320,6 +320,7 @@ class TestExtract:
         with pytest.raises(ModelError, match="Model API error"):
             extract(schema=_Person, model="openai:gpt-5", input_file=str(local))
 
+<<<<<<< HEAD
     def test_anthropic_api_error_is_wrapped_as_model_error(self, tmp_path, mocker):
         local = tmp_path / "input.txt"
         local.write_bytes(b"hello")
@@ -390,6 +391,20 @@ class TestExtract:
                 input_file=str(local),
             )
 
+    def test_groq_api_error_is_wrapped_as_model_error(self, tmp_path, mocker):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hello")
+        from groq import APIError as GroqAPIError
+
+        class _FakeGroqError(GroqAPIError):
+            def __init__(self, message: str):
+                # Bypass GroqAPIError.__init__ to avoid constructing request/body objects.
+                Exception.__init__(self, message)
+
+        _make_agent_mock(mocker, run_sync_side_effect=_FakeGroqError("rate limited"))
+
+        with pytest.raises(ModelError, match="Model API error"):
+            extract(schema=_Person, model="groq:llama-3.3-70b-versatile", input_file=str(local))
 
     def test_message_mentioning_model_is_wrapped_as_extraction_error(self, tmp_path, mocker):
         local = tmp_path / "input.txt"

--- a/uv.lock
+++ b/uv.lock
@@ -759,6 +759,23 @@ wheels = [
 ]
 
 [[package]]
+name = "groq"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/51/4728c13611849ff6cf8536740ae78ba3ee5e665d67b572a47c9ead0f9788/groq-1.2.0.tar.gz", hash = "sha256:85459e27c9c17f22404349c785cd08680362cfe85e07cc060be46c4832f108c3", size = 155609, upload-time = "2026-04-18T10:43:50.68Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/82/748639c95c60ad8846c65b167ca611c815d06d5f67a9e73b23486dce4fdf/groq-1.2.0-py3-none-any.whl", hash = "sha256:1002060a743b27c8f86765e1bc9749c98498e961d9fe2e4902bf7804a71c3c84", size = 142334, upload-time = "2026-04-18T10:43:49.125Z" },
+]
+
+[[package]]
 name = "grpcio"
 version = "1.80.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1176,7 +1193,7 @@ version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
-    { name = "pydantic-ai-slim", extra = ["anthropic", "bedrock", "cohere", "google", "huggingface", "logfire", "openai", "xai"] },
+    { name = "pydantic-ai-slim", extra = ["anthropic", "bedrock", "cohere", "google", "groq", "huggingface", "logfire", "openai", "xai"] },
     { name = "python-dotenv" },
 ]
 
@@ -1192,7 +1209,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5" },
-    { name = "pydantic-ai-slim", extras = ["anthropic", "bedrock", "cohere", "google", "huggingface", "logfire", "openai", "xai"], specifier = ">=1.37.0" },
+    { name = "pydantic-ai-slim", extras = ["anthropic", "bedrock", "cohere", "google", "groq", "huggingface", "logfire", "openai", "xai"], specifier = ">=1.37.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
 ]
 
@@ -1529,6 +1546,9 @@ cohere = [
 ]
 google = [
     { name = "google-genai" },
+]
+groq = [
+    { name = "groq" },
 ]
 huggingface = [
     { name = "huggingface-hub" },


### PR DESCRIPTION
## Summary
- Extend the `pydantic-ai-slim` extras with `groq` so Groq models work out of the box via the `groq:` prefix (e.g. `groq:llama-3.3-70b-versatile`).
- Register `groq.APIError` in `_collect_model_error_types` so Groq provider failures are wrapped as `ModelError`, mirroring the OpenAI handling.
- Document the new provider in the README table and note it under `## [Unreleased]` in the changelog.