### PR TITLE
feat: add Cerebras provider support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add Cohere provider support (extra `pydantic-ai-slim[cohere]`; `cohere.core.api_error.ApiError` wrapped as `ModelError`).
 - Add Hugging Face provider support (extra `pydantic-ai-slim[huggingface]`; `huggingface_hub.errors.HfHubHTTPError` wrapped as `ModelError`).
 - Add Groq provider support (extra `pydantic-ai-slim[groq]`; `groq.APIError` wrapped as `ModelError`).
+- Add Cerebras provider support (model identifiers prefixed `cerebras:`, e.g. `cerebras:llama3.1-70b`). Uses the existing `openai` extra under the hood; set `CEREBRAS_API_KEY` in your environment.
 
 ## [0.5.0] - 2026-05-16
 - Add `extract_async` for async extraction using `Agent.run`.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 - **Type-safe output.** Define your shape with Pydantic; get back a validated instance.
 - **One function, many modalities.** Documents (PDF, DOCX), images, audio, and video.
 - **Local files or URLs.** Pass a path or an `https://` URL &mdash; `openextract` handles fetching.
-- **Bring your own model.** OpenAI, Anthropic, Google, AWS Bedrock, xAI, Cohere, Hugging Face, Groq, and Ollama supported out of the box via [`pydantic-ai`](https://github.com/pydantic/pydantic-ai).
+- **Bring your own model.** OpenAI, Anthropic, Google, AWS Bedrock, xAI, Cohere, Hugging Face, Groq, Cerebras, and Ollama supported out of the box via [`pydantic-ai`](https://github.com/pydantic/pydantic-ai).
 - **Explicit error handling.** Distinct exceptions for URL fetch, schema validation, and model errors.
 - **100% test coverage**, enforced in CI.
 
@@ -135,6 +135,7 @@ print(f"tokens: {usage.input_tokens} in / {usage.output_tokens} out / {usage.tot
 | Cohere       | `cohere:command-r-plus`                             |
 | Hugging Face | `huggingface:meta-llama/Llama-3.3-70B-Instruct`     |
 | Groq         | `groq:llama-3.3-70b-versatile`                      |
+| Cerebras     | `cerebras:llama3.1-70b`                             |
 | Ollama       | `ollama:llama3`                                     |
 
 Set the corresponding provider credentials in your environment (e.g. `OPENAI_API_KEY`). `openextract` loads `.env` automatically.


### PR DESCRIPTION
## Summary
- Document Cerebras as a supported pydantic-ai provider in the README model table and the Features tagline, with `cerebras:llama3.1-70b` as the example identifier.
- Add an Unreleased entry to CHANGELOG noting the new provider and the `CEREBRAS_API_KEY` env var.
- No code or dependency changes required: pydantic-ai's `CerebrasProvider` runs through the OpenAI client, so the existing `openai` extra and `openai.APIError` mapping in `_collect_model_error_types()` already cover Cerebras error handling. The `pydantic-ai-slim[cerebras]` extra does not exist in the resolved version (1.77.0), so it was not added to dependencies.