### PR TITLE
feat: add OpenRouter provider support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add Hugging Face provider support (extra `pydantic-ai-slim[huggingface]`; `huggingface_hub.errors.HfHubHTTPError` wrapped as `ModelError`).
 - Add Groq provider support (extra `pydantic-ai-slim[groq]`; `groq.APIError` wrapped as `ModelError`).
 - Add Cerebras provider support (model identifiers prefixed `cerebras:`, e.g. `cerebras:llama3.1-70b`). Uses the existing `openai` extra under the hood; set `CEREBRAS_API_KEY` in your environment.
+- Add OpenRouter provider support (extra `pydantic-ai-slim[openrouter]`; openai-compatible so existing exception classification applies).
 
 ## [0.5.0] - 2026-05-16
 - Add `extract_async` for async extraction using `Agent.run`.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,10 @@ print(f"tokens: {usage.input_tokens} in / {usage.output_tokens} out / {usage.tot
 | Hugging Face | `huggingface:meta-llama/Llama-3.3-70B-Instruct`     |
 | Groq         | `groq:llama-3.3-70b-versatile`                      |
 | Cerebras     | `cerebras:llama3.1-70b`                             |
+| OpenRouter   | `openrouter:anthropic/claude-sonnet-4`              |
 | Ollama       | `ollama:llama3`                                     |
+
+OpenRouter and Cerebras are openai-compatible (they go through the `openai` client under the hood), so their errors are already classified via the existing openai path &mdash; no separate exception handling is needed.
 
 Set the corresponding provider credentials in your environment (e.g. `OPENAI_API_KEY`). `openextract` loads `.env` automatically.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "pydantic>=2.12.5",
-    "pydantic-ai-slim[anthropic,bedrock,cohere,google,groq,huggingface,logfire,openai,xai]>=1.37.0",
+    "pydantic-ai-slim[anthropic,bedrock,cohere,google,groq,huggingface,logfire,openai,openrouter,xai]>=1.37.0",
     "python-dotenv>=1.2.2",
 ]
 

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -44,6 +44,7 @@ def _collect_model_error_types() -> tuple[type[BaseException], ...]:
         pass
 
     try:
+        # Also covers OpenRouter, which uses the openai SDK under the hood.
         from openai import APIError as OpenAIAPIError
 
         error_types.append(OpenAIAPIError)

--- a/uv.lock
+++ b/uv.lock
@@ -1193,7 +1193,7 @@ version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
-    { name = "pydantic-ai-slim", extra = ["anthropic", "bedrock", "cohere", "google", "groq", "huggingface", "logfire", "openai", "xai"] },
+    { name = "pydantic-ai-slim", extra = ["anthropic", "bedrock", "cohere", "google", "groq", "huggingface", "logfire", "openai", "openrouter", "xai"] },
     { name = "python-dotenv" },
 ]
 
@@ -1209,7 +1209,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5" },
-    { name = "pydantic-ai-slim", extras = ["anthropic", "bedrock", "cohere", "google", "groq", "huggingface", "logfire", "openai", "xai"], specifier = ">=1.37.0" },
+    { name = "pydantic-ai-slim", extras = ["anthropic", "bedrock", "cohere", "google", "groq", "huggingface", "logfire", "openai", "openrouter", "xai"], specifier = ">=1.37.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
 ]
 
@@ -1559,6 +1559,9 @@ logfire = [
 openai = [
     { name = "openai" },
     { name = "tiktoken" },
+]
+openrouter = [
+    { name = "openai" },
 ]
 xai = [
     { name = "xai-sdk" },


### PR DESCRIPTION
## Summary
- Extend `pydantic-ai-slim` with the `openrouter` extra so OpenRouter is installable out of the box.
- Document OpenRouter in the README provider table (example identifier `openrouter:anthropic/claude-sonnet-4`) and note that it is openai-compatible, so existing exception classification covers it.
- Add a one-line comment in `_collect_model_error_types` clarifying that the openai entry also handles OpenRouter errors.
- Record the change under `## [Unreleased]` in the changelog.