### PR TITLE
feat: document Outlines provider support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add Cerebras provider support (model identifiers prefixed `cerebras:`, e.g. `cerebras:llama3.1-70b`). Uses the existing `openai` extra under the hood; set `CEREBRAS_API_KEY` in your environment.
 - Add OpenRouter provider support (extra `pydantic-ai-slim[openrouter]`; openai-compatible so existing exception classification applies).
 - Add Mistral provider support (extra `pydantic-ai-slim[mistral]`; `mistralai.client.errors.mistralerror.MistralError` wrapped as `ModelError`).
+- Document Outlines provider support (`outlines:` prefix; install separately with a backend extra such as `pydantic-ai-slim[outlines-transformers]`).
 
 ## [0.5.0] - 2026-05-16
 - Add `extract_async` for async extraction using `Agent.run`.

--- a/README.md
+++ b/README.md
@@ -125,24 +125,27 @@ print(f"tokens: {usage.input_tokens} in / {usage.output_tokens} out / {usage.tot
 
 `model` follows the `pydantic-ai` provider prefix convention:
 
-| Provider     | Example identifier                                  |
-| ------------ | --------------------------------------------------- |
-| OpenAI       | `openai:gpt-5`                                      |
-| Anthropic    | `anthropic:claude-sonnet-4`                         |
-| Google       | `google-gla:gemini-2.5-pro`                         |
-| AWS Bedrock  | `bedrock:anthropic.claude-sonnet-4-20250514-v1:0`   |
-| xAI          | `xai:grok-4`                                        |
-| Cohere       | `cohere:command-r-plus`                             |
-| Hugging Face | `huggingface:meta-llama/Llama-3.3-70B-Instruct`     |
-| Groq         | `groq:llama-3.3-70b-versatile`                      |
-| Cerebras     | `cerebras:llama3.1-70b`                             |
-| Mistral      | `mistral:mistral-large-latest`                      |
-| OpenRouter   | `openrouter:anthropic/claude-sonnet-4`              |
-| Ollama       | `ollama:llama3`                                     |
+| Provider     | Example identifier                                       |
+| ------------ | -------------------------------------------------------- |
+| OpenAI       | `openai:gpt-5`                                           |
+| Anthropic    | `anthropic:claude-sonnet-4`                              |
+| Google       | `google-gla:gemini-2.5-pro`                              |
+| AWS Bedrock  | `bedrock:anthropic.claude-sonnet-4-20250514-v1:0`        |
+| xAI          | `xai:grok-4`                                             |
+| Cohere       | `cohere:command-r-plus`                                  |
+| Hugging Face | `huggingface:meta-llama/Llama-3.3-70B-Instruct`          |
+| Groq         | `groq:llama-3.3-70b-versatile`                           |
+| Cerebras     | `cerebras:llama3.1-70b`                                  |
+| Mistral      | `mistral:mistral-large-latest`                           |
+| OpenRouter   | `openrouter:anthropic/claude-sonnet-4`                   |
+| Outlines     | `outlines:transformers/meta-llama/Llama-3.2-1B-Instruct` |
+| Ollama       | `ollama:llama3`                                          |
+
+Set the corresponding provider credentials in your environment (e.g. `OPENAI_API_KEY`). `openextract` loads `.env` automatically.
 
 OpenRouter and Cerebras are openai-compatible (they go through the `openai` client under the hood), so their errors are already classified via the existing openai path &mdash; no separate exception handling is needed.
 
-Set the corresponding provider credentials in your environment (e.g. `OPENAI_API_KEY`). `openextract` loads `.env` automatically.
+Outlines runs models locally (via HuggingFace transformers, llama-cpp, MLX, vLLM, or SGLang) and enforces JSON-schema-conforming output at the token level. Install it separately alongside the backend you want, for example `pip install pydantic-ai-slim[outlines-transformers]`.
 
 ### Command line
 


### PR DESCRIPTION
## Summary
- Add an Outlines row to the provider table in the README, with an example identifier and a brief note that it runs models locally with structured-output enforcement.
- Mention the optional `pydantic-ai-slim` outlines extras (e.g. `outlines-transformers`) so users know how to install the backend they want.
- Record the change under `## [Unreleased]` in the changelog.

Outlines is not added as a hard dependency because `pydantic-ai-slim` 1.77.0 does not expose a plain `outlines` extra; only backend-specific variants (`outlines-transformers`, `outlines-llamacpp`, etc.) are available, so install is left to the user.