### PR TITLE
fix: resolve leftover conflict markers in _extract.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
 [tool.ruff]
 line-length = 100
 target-version = "py312"
+extend-exclude = [".claude"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM"]

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -65,17 +65,17 @@ def _collect_model_error_types() -> tuple[type[BaseException], ...]:
         pass
 
     try:
-<<<<<<< HEAD
         from botocore.exceptions import ClientError as BedrockClientError
 
         error_types.append(BedrockClientError)
     except ImportError:  # pragma: no cover - bedrock extra is installed
-=======
+        pass
+
+    try:
         from cohere.core.api_error import ApiError as CohereApiError
 
         error_types.append(CohereApiError)
     except ImportError:  # pragma: no cover - cohere extra is installed
->>>>>>> d53bbf2 (feat: add Cohere provider support)
         pass
 
     return tuple(error_types)


### PR DESCRIPTION
## Summary

PR #72 (Cohere) was admin-merged with unresolved conflict markers in `_collect_model_error_types()` between the Bedrock and Cohere provider blocks, leaving `main` un-importable. Both `try/except ImportError` blocks are now properly separated.

Also extends ruff's exclude list with `.claude/` so transient agent worktrees don't pollute lint output.