### PR TITLE
fix: strip stray conflict marker in tests/test_extract.py

### DIFF
--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -320,7 +320,6 @@ class TestExtract:
         with pytest.raises(ModelError, match="Model API error"):
             extract(schema=_Person, model="openai:gpt-5", input_file=str(local))
 
-<<<<<<< HEAD
     def test_anthropic_api_error_is_wrapped_as_model_error(self, tmp_path, mocker):
         local = tmp_path / "input.txt"
         local.write_bytes(b"hello")


### PR DESCRIPTION
Single leftover `<<<<<<<` marker on line 323 (no matching tail markers) was force-pushed via PR #75's rebase, breaking pytest collection on main. This deletes the stray line.