### PR TITLE
release: 0.6.0 (providers + landing page)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
-- Add Anthropic provider support (extra `pydantic-ai-slim[anthropic]`; provider errors wrapped as `ModelError`).
+## [0.6.0] - 2026-05-16
+- Add Anthropic provider support (extra `pydantic-ai-slim[anthropic]`; `anthropic.APIError` wrapped as `ModelError`).
 - Add AWS Bedrock provider support (extra `pydantic-ai-slim[bedrock]`; `botocore.exceptions.ClientError` wrapped as `ModelError`).
 - Add xAI (Grok) provider support (extra `pydantic-ai-slim[xai]`).
 - Add Cohere provider support (extra `pydantic-ai-slim[cohere]`; `cohere.core.api_error.ApiError` wrapped as `ModelError`).
 - Add Hugging Face provider support (extra `pydantic-ai-slim[huggingface]`; `huggingface_hub.errors.HfHubHTTPError` wrapped as `ModelError`).
 - Add Groq provider support (extra `pydantic-ai-slim[groq]`; `groq.APIError` wrapped as `ModelError`).
-- Add Cerebras provider support (model identifiers prefixed `cerebras:`, e.g. `cerebras:llama3.1-70b`). Uses the existing `openai` extra under the hood; set `CEREBRAS_API_KEY` in your environment.
-- Add OpenRouter provider support (extra `pydantic-ai-slim[openrouter]`; openai-compatible so existing exception classification applies).
 - Add Mistral provider support (extra `pydantic-ai-slim[mistral]`; `mistralai.client.errors.mistralerror.MistralError` wrapped as `ModelError`).
+- Add OpenRouter provider support (extra `pydantic-ai-slim[openrouter]`; openai-compatible, so the existing `openai.APIError` classification applies).
+- Document Cerebras provider support (`cerebras:` prefix; openai-compatible — no dedicated extra needed).
 - Document Outlines provider support (`outlines:` prefix; install separately with a backend extra such as `pydantic-ai-slim[outlines-transformers]`).
 - Clarify Ollama support: it works via the `openai`-compatible code path; `pydantic-ai-slim` does not publish a dedicated `ollama` extra, so no separate dependency is required.
 
@@ -54,7 +54,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.1.1] - 2025-09-10
 - Merge pull request #12 from Mellow-Artificial-Intelligence/new-release.
 
-[Unreleased]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.3.1...v0.3.2

--- a/docs/index.html
+++ b/docs/index.html
@@ -98,9 +98,9 @@
           <!-- Badge -->
           <a href="#whats-new" class="animate-slide-up opacity-0 inline-flex items-center gap-2.5 px-3 py-1.5 border border-black/10 bg-white text-xs mb-8 hover:border-black/30 transition-colors">
             <span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>
-            <span class="font-mono text-black/50">v0.5.0</span>
+            <span class="font-mono text-black/50">v0.6.0</span>
             <span class="text-black/30">|</span>
-            <span class="text-black/50">async, batch, retry, CLI</span>
+            <span class="text-black/50">11 providers, typed errors</span>
           </a>
 
           <!-- Headline -->
@@ -188,7 +188,7 @@
               </div>
               <h3 class="font-mono text-sm font-medium text-black/80 mb-2">Any LLM</h3>
               <p class="text-sm text-black/40 leading-relaxed">
-                OpenAI, Google, and Ollama out of the box. One model string, zero config.
+                11 providers wired in: OpenAI, Anthropic, Google, AWS Bedrock, xAI, Cohere, Hugging Face, Groq, Mistral, OpenRouter, and Ollama.
               </p>
             </div>
 
@@ -206,18 +206,48 @@
         </div>
       </section>
 
-      <!-- What's new in 0.5.0 -->
+      <!-- What's new in 0.6.0 -->
       <section id="whats-new" class="py-16 sm:py-24 border-t border-black/5 scroll-mt-14">
         <div class="max-w-5xl mx-auto px-4 sm:px-6">
           <div class="flex items-baseline justify-between mb-8 sm:mb-10 flex-wrap gap-3">
             <div>
               <p class="font-mono text-[11px] text-black/30 uppercase tracking-wider mb-2">What&rsquo;s new</p>
-              <h2 class="text-2xl sm:text-3xl font-bold text-black/90">v0.5.0</h2>
+              <h2 class="text-2xl sm:text-3xl font-bold text-black/90">v0.6.0</h2>
             </div>
             <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/CHANGELOG.md" class="font-mono text-xs text-black/40 hover:text-black/70 transition-colors inline-flex items-center gap-1.5">
               Full changelog <i data-lucide="arrow-up-right" class="w-3 h-3"></i>
             </a>
           </div>
+
+          <div class="p-6 border border-black/10 bg-white mb-3 sm:mb-4">
+            <div class="flex items-center gap-3 mb-3">
+              <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
+                <i data-lucide="layers" class="w-4 h-4 text-black/50"></i>
+              </div>
+              <span class="font-mono text-[10px] text-black/30 uppercase tracking-wider">v0.6.0 &middot; Providers</span>
+            </div>
+            <h3 class="font-mono text-base font-medium text-black/80 mb-2">11 model providers, one model string</h3>
+            <p class="text-sm text-black/40 leading-relaxed mb-4">
+              v0.6.0 wires every provider that <code class="font-mono text-black/60 text-xs">pydantic-ai</code> ships. Each provider&rsquo;s native error type is wrapped into <code class="font-mono text-black/60 text-xs">ModelError</code> automatically &mdash; no provider-specific catch blocks.
+            </p>
+            <div class="flex flex-wrap gap-1.5">
+              <span class="font-mono text-[11px] text-black/60 border border-black/10 px-2 py-1">openai</span>
+              <span class="font-mono text-[11px] text-black/60 border border-black/10 px-2 py-1">anthropic</span>
+              <span class="font-mono text-[11px] text-black/60 border border-black/10 px-2 py-1">google</span>
+              <span class="font-mono text-[11px] text-black/60 border border-black/10 px-2 py-1">bedrock</span>
+              <span class="font-mono text-[11px] text-black/60 border border-black/10 px-2 py-1">xai</span>
+              <span class="font-mono text-[11px] text-black/60 border border-black/10 px-2 py-1">cohere</span>
+              <span class="font-mono text-[11px] text-black/60 border border-black/10 px-2 py-1">huggingface</span>
+              <span class="font-mono text-[11px] text-black/60 border border-black/10 px-2 py-1">groq</span>
+              <span class="font-mono text-[11px] text-black/60 border border-black/10 px-2 py-1">cerebras</span>
+              <span class="font-mono text-[11px] text-black/60 border border-black/10 px-2 py-1">mistral</span>
+              <span class="font-mono text-[11px] text-black/60 border border-black/10 px-2 py-1">openrouter</span>
+              <span class="font-mono text-[11px] text-black/60 border border-black/10 px-2 py-1">outlines</span>
+              <span class="font-mono text-[11px] text-black/60 border border-black/10 px-2 py-1">ollama</span>
+            </div>
+          </div>
+
+          <p class="font-mono text-[11px] text-black/30 uppercase tracking-wider mt-8 mb-3">Carried forward from v0.5.0</p>
 
           <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4">
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openextract"
-version = "0.5.0"
+version = "0.6.0"
 description = "Extract structured data from documents, images, audio, and video using LLMs"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1229,7 +1229,7 @@ wheels = [
 
 [[package]]
 name = "openextract"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Tags `0.6.0` covering the provider expansion that landed via PRs #69-#79, plus a matching landing-page refresh.

### 0.6.0 includes
- **Providers**: Anthropic, AWS Bedrock, xAI, Cohere, Hugging Face, Groq, Mistral, OpenRouter added as installable extras with typed exception classification. Cerebras and Outlines documented (no dedicated `pydantic-ai-slim` extra published yet). Ollama clarified — it works via the openai-compatible path, no extra required.
- **Landing page**: version badge bumped to `v0.6.0`, "What's new" section gains a top banner highlighting the 12 supported provider prefixes (chips), with the v0.5.0 feature cards preserved as carried-forward reference. Any-LLM feature card text updated to list all 11 providers.
- **CHANGELOG**: `## [Unreleased]` block promoted to `## [0.6.0] - 2026-05-16` with footer link.

89 tests, 100% line + branch coverage, lint clean.

The Release workflow on `main` will tag `v0.6.0`, build, publish to PyPI, and cut the GitHub release on merge.