### PR TITLE
chore: drop peter-evans action from embargo workflow

### DIFF
--- a/.github/workflows/embargo-bump.yml
+++ b/.github/workflows/embargo-bump.yml
@@ -46,13 +46,26 @@ jobs:
       - name: Re-lock dependencies
         run: uv lock
 
-      - name: Open PR if anything changed
-        uses: peter-evans/create-pull-request@v6
-        with:
-          branch: chore/embargo-bump
-          commit-message: "chore: bump dependency embargo to ${{ steps.cutoff.outputs.value }}"
-          title: "chore: bump dependency embargo to ${{ steps.cutoff.outputs.value }}"
-          body: |
-            Daily rolling 24h supply-chain embargo bump. Refuses any package version
-            published after `${{ steps.cutoff.outputs.value }}`.
-          delete-branch: true
+      - name: Open or update PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_CUTOFF: ${{ steps.cutoff.outputs.value }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- pyproject.toml uv.lock; then
+            echo "No changes - embargo already current."
+            exit 0
+          fi
+          BRANCH=chore/embargo-bump
+          TITLE="chore: bump dependency embargo to ${NEW_CUTOFF}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add pyproject.toml uv.lock
+          git commit -m "$TITLE"
+          git push --force-with-lease origin "$BRANCH"
+          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            gh pr edit "$BRANCH" --title "$TITLE" --body "Daily rolling 24h supply-chain embargo bump. Refuses any package version published after \`${NEW_CUTOFF}\`."
+          else
+            gh pr create --head "$BRANCH" --base main --title "$TITLE" --body "Daily rolling 24h supply-chain embargo bump. Refuses any package version published after \`${NEW_CUTOFF}\`."
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ The policy is enforced via uv's `exclude-newer` setting in `pyproject.toml`:
 exclude-newer = "<YYYY-MM-DDTHH:MM:SSZ>"
 ```
 
-A scheduled GitHub Actions workflow (`.github/workflows/embargo-bump.yml`) runs daily at 03:00 UTC and opens a PR that advances the cutoff to "yesterday 00:00 UTC". Merge those PRs as part of normal review.
+A scheduled GitHub Actions workflow (`.github/workflows/embargo-bump.yml`) runs daily at 03:00 UTC and opens a PR that advances the cutoff to "yesterday 00:00 UTC". Merge those PRs as part of normal review. The workflow uses only first-party tooling (the `gh` CLI preinstalled on GitHub-hosted runners and `astral-sh/setup-uv`) — no third-party PR-creation actions, to keep the supply-chain surface for the embargo workflow itself minimal.
 
 If you need to add a dependency that was published in the last 24 hours, hold off and wait the embargo out rather than bumping `exclude-newer` past the rolling window.
 


### PR DESCRIPTION
## Summary

The embargo workflow (`.github/workflows/embargo-bump.yml`) was using `peter-evans/create-pull-request@v6` to open its daily PR. A workflow whose purpose is to harden the supply chain shouldn't itself depend on a third-party action, so the "Open PR" step now uses the native `gh` CLI (preinstalled on GitHub-hosted runners). Same behavior for reviewers — one PR per day on `chore/embargo-bump`, idempotently updated if it already exists.

\`astral-sh/setup-uv\` stays — it's the canonical action published by uv's maintainer (Astral).

CONTRIBUTING.md updated to note that the embargo workflow uses only first-party tooling.