### PR TITLE
security: SSRF defenses on URL fetch, SHA-pin GitHub Actions, refresh SECURITY.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
       - run: uv sync --dev
       - run: uv run ruff check .
       - run: uv run ruff format --check .
@@ -19,8 +19,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
       - run: uv sync --dev
       - name: Run tests
         run: uv run pytest -v --cov=openextract --cov-report=term-missing --cov-fail-under=0

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,14 +29,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5.0.0
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
         with:
           # Upload docs directory
           path: './docs'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4.0.5

--- a/.github/workflows/embargo-bump.yml
+++ b/.github/workflows/embargo-bump.yml
@@ -16,8 +16,8 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
 
       - name: Compute new cutoff (24h ago, UTC midnight)
         id: cutoff

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,11 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
 
       - name: Get version from pyproject.toml
         id: version
@@ -48,11 +48,11 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.check_release.outputs.exists == 'false'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
 
       - name: Create GitHub Release
         if: steps.check_release.outputs.exists == 'false'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2.2.1
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: ${{ steps.version.outputs.tag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+### Security
+- URL fetching now refuses hosts that resolve to non-public addresses
+  (private/loopback/link-local/multicast/reserved, IPv4 and IPv6, including
+  IPv4-mapped IPv6 and the `169.254.169.254` cloud-metadata endpoint) to
+  reduce SSRF risk when callers pass untrusted URLs. The check is re-applied
+  at every redirect hop; set `OPENEXTRACT_ALLOW_PRIVATE_URLS=1` to opt out.
+  **Breaking** for callers that previously fetched `localhost`/internal
+  hosts via `extract()`.
+- Pinned all GitHub Actions to commit SHAs.
+
 ## [0.6.0] - 2026-05-16
 - Add Anthropic provider support (extra `pydantic-ai-slim[anthropic]`; `anthropic.APIError` wrapped as `ModelError`).
 - Add AWS Bedrock provider support (extra `pydantic-ai-slim[bedrock]`; `botocore.exceptions.ClientError` wrapped as `ModelError`).

--- a/README.md
+++ b/README.md
@@ -229,6 +229,35 @@ All `openextract` exceptions inherit from `ExtractionError`, so you can catch it
 
 Returns an instance of `schema`.
 
+## Security
+
+### URL fetching and SSRF
+
+When `input_file` is an `http://` or `https://` URL, `openextract` fetches it
+directly. To reduce server-side request forgery risk when callers pass
+untrusted URLs, the fetcher refuses any URL whose host resolves to a
+non-public address &mdash; private RFC 1918 ranges, loopback, link-local (including
+the `169.254.169.254` cloud-metadata endpoint), multicast, and reserved
+ranges, for both IPv4 and IPv6 (including IPv4-mapped IPv6 like
+`::ffff:127.0.0.1`). The host is re-validated at every redirect hop, so an
+attacker cannot use a public URL that redirects to an internal one.
+
+For workflows that legitimately need to fetch internal URLs (testing
+against `localhost`, on-prem services, etc.), set the
+`OPENEXTRACT_ALLOW_PRIVATE_URLS` environment variable to `1`, `true`, or
+`yes` to disable the check. If you need a one-off fetch from an internal
+host without disabling validation globally, fetch the bytes with your own
+HTTP client and pass them to `extract()` as `bytes`/file-like with an
+explicit `media_type`.
+
+> **Note:** host validation is best-effort; it does not defend against DNS
+> rebinding (where the host resolves to different IPs across calls). Treat
+> URL-based extraction of untrusted input as a privileged operation.
+
+### Reporting vulnerabilities
+
+See [SECURITY.md](SECURITY.md).
+
 ## Development
 
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.2.x   | :white_check_mark: |
-| 0.1.x   | :x:                |
+| 0.6.x   | :white_check_mark: |
+| < 0.6   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -1,13 +1,17 @@
 """Core extraction functionality."""
 
 import asyncio
+import ipaddress
 import mimetypes
+import os
 import random
+import socket
 import time
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import BinaryIO, TypeVar
+from urllib.parse import urlparse
 
 import httpx
 from dotenv import load_dotenv
@@ -22,6 +26,8 @@ T = TypeVar("T", bound=BaseModel)
 _DEFAULT_MEDIA_TYPE = "application/octet-stream"
 _URL_PREFIXES = ("http://", "https://")
 _URL_FETCH_TIMEOUT = 30.0
+_MAX_REDIRECTS = 10
+_ALLOW_PRIVATE_URLS_ENV = "OPENEXTRACT_ALLOW_PRIVATE_URLS"
 _BYTES_MEDIA_TYPE_REQUIRED = (
     "media_type is required when input_file is bytes or a file-like object; "
     "pass it explicitly, e.g. extract(..., media_type='application/pdf')."
@@ -121,11 +127,78 @@ def _get_media_type(file_path: str) -> str:
     return media_type or _DEFAULT_MEDIA_TYPE
 
 
+def _allow_private_urls() -> bool:
+    """Return True when SSRF host validation is disabled via env var."""
+    return os.environ.get(_ALLOW_PRIVATE_URLS_ENV, "").lower() in ("1", "true", "yes")
+
+
+def _is_public_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return True only for globally routable public unicast addresses.
+
+    Treats IPv4-mapped IPv6 (``::ffff:a.b.c.d``) as its underlying IPv4 so
+    that e.g. ``::ffff:127.0.0.1`` is correctly classified as loopback.
+    """
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    return ip.is_global
+
+
+def _is_safe_host(host: str | None) -> bool:
+    """Return True when ``host`` resolves only to public IP addresses.
+
+    Refuses missing/empty hosts, IP literals in private/loopback/link-local/
+    multicast/reserved ranges (including AWS/GCP metadata at
+    ``169.254.169.254``), hostnames that resolve to any non-public IP, and
+    hostnames that fail to resolve. Bypassed by ``OPENEXTRACT_ALLOW_PRIVATE_URLS``.
+    """
+    if _allow_private_urls():
+        return True
+    if not host:
+        return False
+    bare = host.strip("[]")
+    try:
+        return _is_public_ip(ipaddress.ip_address(bare))
+    except ValueError:
+        pass
+    try:
+        infos = socket.getaddrinfo(bare, None)
+    except OSError:
+        return False
+    if not infos:
+        return False
+    for info in infos:
+        try:
+            resolved = ipaddress.ip_address(info[4][0])
+        except ValueError:
+            return False
+        if not _is_public_ip(resolved):
+            return False
+    return True
+
+
+def _fetch_url(url: str) -> httpx.Response:
+    """Fetch ``url`` with SSRF defenses; validate the host at every redirect hop."""
+    current = url
+    for _ in range(_MAX_REDIRECTS):
+        host = urlparse(current).hostname
+        if not _is_safe_host(host):
+            raise UrlFetchError(f"Refusing to fetch URL with non-public host: {host!r}")
+        response = httpx.get(current, follow_redirects=False, timeout=_URL_FETCH_TIMEOUT)
+        if response.is_redirect:
+            location = response.headers.get("location")
+            if not location:
+                raise UrlFetchError(f"Redirect from {current!r} missing Location header")
+            current = str(httpx.URL(current).join(location))
+            continue
+        response.raise_for_status()
+        return response
+    raise UrlFetchError(f"Too many redirects (>{_MAX_REDIRECTS})")
+
+
 def _read_from_path(file_path: str) -> tuple[bytes, str]:
     """Read bytes from a local path or http(s) URL; return (bytes, media_type)."""
     if file_path.startswith(_URL_PREFIXES):
-        response = httpx.get(file_path, follow_redirects=True, timeout=_URL_FETCH_TIMEOUT)
-        response.raise_for_status()
+        response = _fetch_url(file_path)
         media_bytes = response.content
         media_type = _get_media_type(file_path)
         # If the URL extension didn't tell us anything, trust the server's Content-Type.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Shared test fixtures."""
+
+import socket
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _stub_dns(monkeypatch):
+    """Force ``socket.getaddrinfo`` to resolve every hostname to a public IP.
+
+    Keeps the test suite hermetic: SSRF host validation happens for every URL
+    fetch, and we don't want tests reaching real DNS for ``example.com``.
+    Tests that specifically exercise resolution behavior override this fixture
+    via their own ``monkeypatch`` of ``socket.getaddrinfo``.
+    """
+
+    def fake_getaddrinfo(host, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("1.1.1.1", 0))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import io
+import ipaddress
+import socket
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -21,18 +23,34 @@ from openextract import (
     extract_many_async,
     extract_with_usage,
 )
-from openextract._extract import _get_media, _get_media_type
+from openextract._extract import (
+    _fetch_url,
+    _get_media,
+    _get_media_type,
+    _is_public_ip,
+    _is_safe_host,
+)
 
 
 def _build_response(
     *,
     content: bytes = b"",
     content_type: str = "application/octet-stream",
+    is_redirect: bool = False,
+    status_code: int = 200,
+    location: str | None = None,
 ) -> MagicMock:
     """Build a MagicMock that behaves like an httpx.Response."""
     response = MagicMock()
     response.content = content
-    response.headers = {"content-type": content_type} if content_type else {}
+    headers: dict[str, str] = {}
+    if content_type:
+        headers["content-type"] = content_type
+    if location is not None:
+        headers["location"] = location
+    response.headers = headers
+    response.is_redirect = is_redirect
+    response.status_code = status_code
     response.raise_for_status.return_value = None
     return response
 
@@ -130,7 +148,9 @@ class TestGetMedia:
         mock_get.assert_called_once()
         args, kwargs = mock_get.call_args
         assert args[0] == "https://example.com/page.html"
-        assert kwargs["follow_redirects"] is True
+        # follow_redirects is disabled at the httpx layer; redirects are followed
+        # manually in _fetch_url so the SSRF host check runs at every hop.
+        assert kwargs["follow_redirects"] is False
         assert kwargs["timeout"] == 30.0
         assert media_bytes == b"<html>remote</html>"
         assert media_type == "text/html"
@@ -183,6 +203,154 @@ class TestGetMedia:
 
         with pytest.raises(httpx.HTTPStatusError):
             _get_media("https://example.com/missing.pdf")
+
+
+# ---------------------------------------------------------------------------
+# SSRF host validation
+# ---------------------------------------------------------------------------
+
+
+def _addrinfo(ip: str):
+    """Build a getaddrinfo-shaped tuple for ``ip``."""
+    family = socket.AF_INET6 if ":" in ip else socket.AF_INET
+    return [(family, socket.SOCK_STREAM, 0, "", (ip, 0))]
+
+
+class TestIsPublicIp:
+    def test_public_ipv4_is_public(self):
+        assert _is_public_ip(ipaddress.ip_address("1.1.1.1")) is True
+
+    def test_private_ipv4_is_not_public(self):
+        assert _is_public_ip(ipaddress.ip_address("10.0.0.1")) is False
+
+    def test_loopback_ipv4_is_not_public(self):
+        assert _is_public_ip(ipaddress.ip_address("127.0.0.1")) is False
+
+    def test_aws_metadata_link_local_is_not_public(self):
+        assert _is_public_ip(ipaddress.ip_address("169.254.169.254")) is False
+
+    def test_ipv6_loopback_is_not_public(self):
+        assert _is_public_ip(ipaddress.ip_address("::1")) is False
+
+    def test_ipv4_mapped_ipv6_loopback_is_not_public(self):
+        # ::ffff:127.0.0.1 wraps an IPv4 loopback; must be unwrapped and rejected.
+        assert _is_public_ip(ipaddress.ip_address("::ffff:127.0.0.1")) is False
+
+
+class TestIsSafeHost:
+    def test_opt_out_env_var_bypasses_validation(self, monkeypatch):
+        monkeypatch.setenv("OPENEXTRACT_ALLOW_PRIVATE_URLS", "1")
+        # Even a clearly private address is permitted when the opt-out is set.
+        assert _is_safe_host("127.0.0.1") is True
+
+    def test_opt_out_env_var_unset_does_not_bypass(self, monkeypatch):
+        monkeypatch.delenv("OPENEXTRACT_ALLOW_PRIVATE_URLS", raising=False)
+        assert _is_safe_host("127.0.0.1") is False
+
+    def test_empty_host_is_unsafe(self):
+        assert _is_safe_host("") is False
+        assert _is_safe_host(None) is False
+
+    def test_private_ip_literal_is_unsafe(self):
+        assert _is_safe_host("192.168.1.1") is False
+        assert _is_safe_host("169.254.169.254") is False
+
+    def test_public_ip_literal_is_safe(self):
+        assert _is_safe_host("1.1.1.1") is True
+
+    def test_ipv6_literal_in_brackets_is_handled(self):
+        # urlparse strips brackets, but defend in depth: _is_safe_host must too.
+        assert _is_safe_host("[::1]") is False
+
+    def test_hostname_resolving_to_private_ip_is_unsafe(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **k: _addrinfo("10.0.0.5"))
+        assert _is_safe_host("internal.example.com") is False
+
+    def test_hostname_with_dns_failure_is_unsafe(self, monkeypatch):
+        def boom(*args, **kwargs):
+            raise socket.gaierror("nope")
+
+        monkeypatch.setattr(socket, "getaddrinfo", boom)
+        assert _is_safe_host("nonexistent.invalid") is False
+
+    def test_hostname_with_empty_resolution_is_unsafe(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **k: [])
+        assert _is_safe_host("ghost.example.com") is False
+
+    def test_hostname_with_unparseable_resolved_address_is_unsafe(self, monkeypatch):
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            lambda *a, **k: [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("not-an-ip", 0))],
+        )
+        assert _is_safe_host("weird.example.com") is False
+
+
+class TestFetchUrl:
+    def test_refuses_private_host(self):
+        with pytest.raises(UrlFetchError, match="non-public host"):
+            _fetch_url("http://127.0.0.1/secret")
+
+    def test_refuses_aws_metadata_url(self):
+        with pytest.raises(UrlFetchError, match="non-public host"):
+            _fetch_url("http://169.254.169.254/latest/meta-data/")
+
+    def test_follows_safe_redirect(self, mocker):
+        redirect = _build_response(
+            content=b"", status_code=302, is_redirect=True, location="https://2.2.2.2/final.html"
+        )
+        final = _build_response(content=b"ok", content_type="text/html")
+        mock_get = mocker.patch("openextract._extract.httpx.get", side_effect=[redirect, final])
+
+        response = _fetch_url("https://1.1.1.1/start")
+
+        assert response is final
+        assert mock_get.call_count == 2
+        # Both hops must be issued with follow_redirects disabled so our host
+        # check runs each time.
+        for call in mock_get.call_args_list:
+            assert call.kwargs["follow_redirects"] is False
+
+    def test_blocks_redirect_to_private_host(self, mocker):
+        redirect = _build_response(
+            content=b"",
+            status_code=302,
+            is_redirect=True,
+            location="http://169.254.169.254/latest/meta-data/",
+        )
+        mocker.patch("openextract._extract.httpx.get", return_value=redirect)
+
+        with pytest.raises(UrlFetchError, match="non-public host"):
+            _fetch_url("https://1.1.1.1/start")
+
+    def test_redirect_without_location_raises_url_fetch_error(self, mocker):
+        no_location = _build_response(content=b"", status_code=302, is_redirect=True, location=None)
+        mocker.patch("openextract._extract.httpx.get", return_value=no_location)
+
+        with pytest.raises(UrlFetchError, match="missing Location"):
+            _fetch_url("https://1.1.1.1/start")
+
+    def test_too_many_redirects_raises(self, mocker):
+        redirect = _build_response(
+            content=b"", status_code=302, is_redirect=True, location="https://1.1.1.1/loop"
+        )
+        mocker.patch("openextract._extract.httpx.get", return_value=redirect)
+
+        with pytest.raises(UrlFetchError, match="Too many redirects"):
+            _fetch_url("https://1.1.1.1/loop")
+
+
+class TestSsrfIntegration:
+    def test_extract_with_private_url_raises_url_fetch_error(self, mocker):
+        # Agent should never be constructed when the URL is rejected.
+        agent_cls = mocker.patch("openextract._extract.Agent")
+        with pytest.raises(UrlFetchError):
+            extract(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_file="http://169.254.169.254/latest/meta-data/",
+            )
+        agent_cls.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- Reject non-public hosts (private/loopback/link-local/multicast/reserved,
  IPv4 and IPv6, including IPv4-mapped IPv6 and 169.254.169.254 metadata)
  when fetching `http(s)://` URLs in `extract()`. Re-validate at every
  redirect hop. Opt-out via `OPENEXTRACT_ALLOW_PRIVATE_URLS=1`.
- Pin every GitHub Action to a commit SHA with the version in a comment so
  Dependabot can track updates.
- Refresh SECURITY.md (supported versions 0.6.x).
- Document the new SSRF behavior in README and CHANGELOG.
- Add hermetic DNS stub in tests/conftest.py so URL tests don't depend on
  real DNS resolution.

https://claude.ai/code/session_019YGzJRbeahPWBgdzcY53yw