### PR TITLE
refactor: consolidate provider error handling and dedupe tests

### DIFF
--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -1,13 +1,15 @@
 """Core extraction functionality."""
 
 import asyncio
+import importlib
 import ipaddress
 import mimetypes
 import os
 import random
 import socket
 import time
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import BinaryIO, TypeVar
@@ -33,79 +35,35 @@ _BYTES_MEDIA_TYPE_REQUIRED = (
     "pass it explicitly, e.g. extract(..., media_type='application/pdf')."
 )
 
+# (module, attribute) pairs for provider/model error base classes we want to
+# classify as ``ModelError``. ``openai.APIError`` also covers OpenRouter and
+# Cerebras since both go through the openai SDK.
+_PROVIDER_ERROR_PATHS: tuple[tuple[str, str], ...] = (
+    ("pydantic_ai.exceptions", "ModelAPIError"),
+    ("openai", "APIError"),
+    ("anthropic", "APIError"),
+    ("google.genai.errors", "APIError"),
+    ("botocore.exceptions", "ClientError"),
+    ("cohere.core.api_error", "ApiError"),
+    ("huggingface_hub.errors", "HfHubHTTPError"),
+    ("groq", "APIError"),
+    ("mistralai.client.errors.mistralerror", "MistralError"),
+)
+
 
 def _collect_model_error_types() -> tuple[type[BaseException], ...]:
-    """Collect known provider/model error base classes that are importable.
+    """Resolve ``_PROVIDER_ERROR_PATHS`` to importable exception classes.
 
     Each import is guarded so a missing optional provider does not break the
     package. The returned tuple is suitable for use with ``isinstance``.
     """
     error_types: list[type[BaseException]] = []
-
-    try:
-        from pydantic_ai.exceptions import ModelAPIError
-
-        error_types.append(ModelAPIError)
-    except ImportError:  # pragma: no cover - pydantic-ai is a hard dependency
-        pass
-
-    try:
-        # Also covers OpenRouter, which uses the openai SDK under the hood.
-        from openai import APIError as OpenAIAPIError
-
-        error_types.append(OpenAIAPIError)
-    except ImportError:  # pragma: no cover - openai extra is installed
-        pass
-
-    try:
-        from anthropic import APIError as AnthropicAPIError
-
-        error_types.append(AnthropicAPIError)
-    except ImportError:  # pragma: no cover - anthropic extra is installed
-        pass
-
-    try:
-        from google.genai.errors import APIError as GoogleAPIError
-
-        error_types.append(GoogleAPIError)
-    except ImportError:  # pragma: no cover - google extra is installed
-        pass
-
-    try:
-        from botocore.exceptions import ClientError as BedrockClientError
-
-        error_types.append(BedrockClientError)
-    except ImportError:  # pragma: no cover - bedrock extra is installed
-        pass
-
-    try:
-        from cohere.core.api_error import ApiError as CohereApiError
-
-        error_types.append(CohereApiError)
-    except ImportError:  # pragma: no cover - cohere extra is installed
-        pass
-
-    try:
-        from huggingface_hub.errors import HfHubHTTPError
-
-        error_types.append(HfHubHTTPError)
-    except ImportError:  # pragma: no cover - huggingface extra is installed
-        pass
-
-    try:
-        from groq import APIError as GroqAPIError
-
-        error_types.append(GroqAPIError)
-    except ImportError:  # pragma: no cover - groq extra is installed
-        pass
-
-    try:
-        from mistralai.client.errors.mistralerror import MistralError
-
-        error_types.append(MistralError)
-    except ImportError:  # pragma: no cover - mistral extra is installed
-        pass
-
+    for module_name, attr in _PROVIDER_ERROR_PATHS:
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError:  # pragma: no cover - all provider extras are installed
+            continue
+        error_types.append(getattr(module, attr))
     return tuple(error_types)
 
 
@@ -270,6 +228,22 @@ def _map_exception(exc: BaseException) -> ExtractionError:
     return ExtractionError(f"Extraction failed: {exc}")
 
 
+@contextmanager
+def _extraction_errors() -> Iterator[None]:
+    """Map low-level extraction failures to the ``ExtractionError`` hierarchy.
+
+    ``TypeError`` (bad call) and already-mapped ``ExtractionError`` subclasses
+    pass through unchanged; everything else is routed through
+    :func:`_map_exception`.
+    """
+    try:
+        yield
+    except (TypeError, ExtractionError):
+        raise
+    except Exception as e:
+        raise _map_exception(e) from e
+
+
 def _usage_from_result(result) -> Usage:
     """Build a ``Usage`` from a pydantic-ai run result."""
     raw = result.usage()
@@ -278,6 +252,20 @@ def _usage_from_result(result) -> Usage:
         output_tokens=getattr(raw, "output_tokens", 0) or 0,
         total_tokens=getattr(raw, "total_tokens", 0) or 0,
     )
+
+
+def _prepare_run(
+    schema: type[T],
+    model: str,
+    input_file: str | bytes | BinaryIO,
+    instructions: str | None,
+    media_type: str | None,
+) -> tuple[Agent, list]:
+    """Load env, resolve the media payload, and build the agent + run inputs."""
+    load_dotenv()
+    file_bytes, file_type = _get_media(input_file, media_type=media_type)
+    agent = _build_agent(schema, model, instructions)
+    return agent, _build_run_inputs(file_bytes, file_type)
 
 
 def _run_extraction(
@@ -293,17 +281,9 @@ def _run_extraction(
     can be reused by ``extract`` (which discards usage) and
     ``extract_with_usage`` (which surfaces it).
     """
-    try:
-        load_dotenv()
-        file_bytes, file_type = _get_media(input_file, media_type=media_type)
-        agent = _build_agent(schema, model, instructions)
-        return agent.run_sync(_build_run_inputs(file_bytes, file_type))
-    except TypeError:
-        raise
-    except ExtractionError:
-        raise
-    except Exception as e:
-        raise _map_exception(e) from e
+    with _extraction_errors():
+        agent, inputs = _prepare_run(schema, model, input_file, instructions, media_type)
+        return agent.run_sync(inputs)
 
 
 def _extract_once(
@@ -395,18 +375,10 @@ async def extract_async(
     media_type: str | None = None,
 ) -> T:
     """Async sibling of :func:`extract`; uses ``Agent.run`` instead of ``run_sync``."""
-    try:
-        load_dotenv()
-        file_bytes, file_type = _get_media(input_file, media_type=media_type)
-        agent = _build_agent(schema, model, instructions)
-        result = await agent.run(_build_run_inputs(file_bytes, file_type))
+    with _extraction_errors():
+        agent, inputs = _prepare_run(schema, model, input_file, instructions, media_type)
+        result = await agent.run(inputs)
         return result.output
-    except TypeError:
-        raise
-    except ExtractionError:
-        raise
-    except Exception as e:
-        raise _map_exception(e) from e
 
 
 async def _gather_extractions(

--- a/src/openextract/exceptions.py
+++ b/src/openextract/exceptions.py
@@ -4,22 +4,14 @@
 class ExtractionError(Exception):
     """Base exception for extraction errors."""
 
-    pass
-
 
 class ModelError(ExtractionError):
     """Error communicating with the model API."""
-
-    pass
 
 
 class SchemaValidationError(ExtractionError):
     """Model output did not match the expected schema."""
 
-    pass
-
 
 class UrlFetchError(ExtractionError):
     """Error fetching the URL content."""
-
-    pass

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -4,6 +4,7 @@ import asyncio
 import io
 import ipaddress
 import socket
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -363,6 +364,65 @@ class _Person(BaseModel):
     age: int
 
 
+def _make_bare_provider_error(module_name: str, attr: str, message: str) -> Exception:
+    """Build a subclass of a provider's API-error type that bypasses its __init__.
+
+    Most provider error classes require a constructed request/response object;
+    we only care about ``isinstance`` matching, so we skip straight to
+    ``Exception.__init__`` with the message.
+    """
+    import importlib
+
+    base = getattr(importlib.import_module(module_name), attr)
+
+    class _BareProviderError(base):
+        def __init__(self, msg: str):
+            Exception.__init__(self, msg)
+
+    return _BareProviderError(message)
+
+
+def _make_pydantic_ai_error(message: str) -> Exception:
+    from pydantic_ai.exceptions import ModelHTTPError
+
+    return ModelHTTPError(status_code=503, model_name="gpt-5", body=message)
+
+
+def _make_bedrock_error(message: str) -> Exception:
+    from botocore.exceptions import ClientError
+
+    return ClientError(
+        {"Error": {"Code": "ThrottlingException", "Message": message}},
+        "InvokeModel",
+    )
+
+
+def _make_cohere_error(message: str) -> Exception:
+    from cohere.core.api_error import ApiError
+
+    class _BareCohereError(ApiError):
+        def __init__(self, msg: str):
+            Exception.__init__(self, msg)
+            # ApiError.__str__ touches these attributes.
+            self.headers = None
+            self.status_code = 401
+            self.body = msg
+
+    return _BareCohereError(message)
+
+
+def _make_mistral_error(message: str) -> Exception:
+    from mistralai.client.errors.sdkerror import SDKError
+
+    class _BareMistralError(SDKError):
+        def __init__(self, msg: str):
+            Exception.__init__(self, msg)
+            # SDKError uses __slots__; bypass via object.__setattr__.
+            object.__setattr__(self, "message", msg)
+
+    return _BareMistralError(message)
+
+
 def _make_agent_mock(mocker, output=None, run_sync_side_effect=None, usage=None):
     """Patch openextract._extract.Agent and return (AgentClass, instance, run_sync)."""
     agent_instance = MagicMock()
@@ -462,132 +522,52 @@ class TestExtract:
         with pytest.raises(SchemaValidationError, match="Model output did not match schema"):
             extract(schema=_Person, model="openai:gpt-5", input_file=str(local))
 
-    def test_pydantic_ai_model_api_error_is_wrapped_as_model_error(self, tmp_path, mocker):
+    @pytest.mark.parametrize(
+        "factory,model_id",
+        [
+            (lambda msg: _make_pydantic_ai_error(msg), "openai:gpt-5"),
+            (lambda msg: _make_bare_provider_error("openai", "APIError", msg), "openai:gpt-5"),
+            (
+                lambda msg: _make_bare_provider_error("anthropic", "APIError", msg),
+                "anthropic:claude-sonnet-4",
+            ),
+            (
+                lambda msg: _make_bedrock_error(msg),
+                "bedrock:anthropic.claude-sonnet-4-20250514-v1:0",
+            ),
+            (lambda msg: _make_cohere_error(msg), "cohere:command-r-plus"),
+            (
+                lambda msg: _make_bare_provider_error(
+                    "huggingface_hub.errors", "HfHubHTTPError", msg
+                ),
+                "huggingface:meta-llama/Llama-3.3-70B-Instruct",
+            ),
+            (
+                lambda msg: _make_bare_provider_error("groq", "APIError", msg),
+                "groq:llama-3.3-70b-versatile",
+            ),
+            (lambda msg: _make_mistral_error(msg), "mistral:mistral-large-latest"),
+        ],
+        ids=[
+            "pydantic_ai_ModelHTTPError",
+            "openai_APIError",
+            "anthropic_APIError",
+            "bedrock_ClientError",
+            "cohere_ApiError",
+            "huggingface_HfHubHTTPError",
+            "groq_APIError",
+            "mistral_SDKError",
+        ],
+    )
+    def test_provider_api_error_is_wrapped_as_model_error(
+        self, tmp_path, mocker, factory, model_id
+    ):
         local = tmp_path / "input.txt"
         local.write_bytes(b"hello")
-        from pydantic_ai.exceptions import ModelHTTPError
-
-        provider_error = ModelHTTPError(status_code=503, model_name="gpt-5", body="upstream down")
-        _make_agent_mock(mocker, run_sync_side_effect=provider_error)
+        _make_agent_mock(mocker, run_sync_side_effect=factory("rate limited"))
 
         with pytest.raises(ModelError, match="Model API error"):
-            extract(schema=_Person, model="openai:gpt-5", input_file=str(local))
-
-    def test_openai_api_error_is_wrapped_as_model_error(self, tmp_path, mocker):
-        local = tmp_path / "input.txt"
-        local.write_bytes(b"hello")
-        from openai import APIError as OpenAIAPIError
-
-        class _FakeOpenAIError(OpenAIAPIError):
-            def __init__(self, message: str):
-                # Bypass OpenAIAPIError.__init__ to avoid constructing request/body objects.
-                Exception.__init__(self, message)
-
-        _make_agent_mock(mocker, run_sync_side_effect=_FakeOpenAIError("rate limited"))
-
-        with pytest.raises(ModelError, match="Model API error"):
-            extract(schema=_Person, model="openai:gpt-5", input_file=str(local))
-
-    def test_anthropic_api_error_is_wrapped_as_model_error(self, tmp_path, mocker):
-        local = tmp_path / "input.txt"
-        local.write_bytes(b"hello")
-        from anthropic import APIError as AnthropicAPIError
-
-        class _FakeAnthropicError(AnthropicAPIError):
-            def __init__(self, message: str):
-                # Bypass AnthropicAPIError.__init__ to avoid constructing request/body objects.
-                Exception.__init__(self, message)
-
-        _make_agent_mock(mocker, run_sync_side_effect=_FakeAnthropicError("rate limited"))
-
-        with pytest.raises(ModelError, match="Model API error"):
-            extract(schema=_Person, model="anthropic:claude-sonnet-4", input_file=str(local))
-
-    def test_bedrock_client_error_is_wrapped_as_model_error(self, tmp_path, mocker):
-        local = tmp_path / "input.txt"
-        local.write_bytes(b"hello")
-        from botocore.exceptions import ClientError as BedrockClientError
-
-        provider_error = BedrockClientError(
-            {"Error": {"Code": "ThrottlingException", "Message": "rate limited"}},
-            "InvokeModel",
-        )
-        _make_agent_mock(mocker, run_sync_side_effect=provider_error)
-
-        with pytest.raises(ModelError, match="Model API error"):
-            extract(
-                schema=_Person,
-                model="bedrock:anthropic.claude-sonnet-4-20250514-v1:0",
-                input_file=str(local),
-            )
-
-    def test_cohere_api_error_is_wrapped_as_model_error(self, tmp_path, mocker):
-        local = tmp_path / "input.txt"
-        local.write_bytes(b"hello")
-        from cohere.core.api_error import ApiError as CohereApiError
-
-        class _FakeCohereError(CohereApiError):
-            def __init__(self, message: str):
-                # Bypass CohereApiError.__init__; populate the attributes its __str__ needs.
-                Exception.__init__(self, message)
-                self.headers = None
-                self.status_code = 401
-                self.body = message
-
-        _make_agent_mock(mocker, run_sync_side_effect=_FakeCohereError("unauthorized"))
-
-        with pytest.raises(ModelError, match="Model API error"):
-            extract(schema=_Person, model="cohere:command-r-plus", input_file=str(local))
-
-    def test_huggingface_http_error_is_wrapped_as_model_error(self, tmp_path, mocker):
-        local = tmp_path / "input.txt"
-        local.write_bytes(b"hello")
-        from huggingface_hub.errors import HfHubHTTPError
-
-        class _FakeHfHubHTTPError(HfHubHTTPError):
-            def __init__(self, message: str):
-                # Bypass HfHubHTTPError.__init__ to avoid constructing a Response object.
-                Exception.__init__(self, message)
-
-        _make_agent_mock(mocker, run_sync_side_effect=_FakeHfHubHTTPError("hf upstream down"))
-
-        with pytest.raises(ModelError, match="Model API error"):
-            extract(
-                schema=_Person,
-                model="huggingface:meta-llama/Llama-3.3-70B-Instruct",
-                input_file=str(local),
-            )
-
-    def test_groq_api_error_is_wrapped_as_model_error(self, tmp_path, mocker):
-        local = tmp_path / "input.txt"
-        local.write_bytes(b"hello")
-        from groq import APIError as GroqAPIError
-
-        class _FakeGroqError(GroqAPIError):
-            def __init__(self, message: str):
-                # Bypass GroqAPIError.__init__ to avoid constructing request/body objects.
-                Exception.__init__(self, message)
-
-        _make_agent_mock(mocker, run_sync_side_effect=_FakeGroqError("rate limited"))
-
-        with pytest.raises(ModelError, match="Model API error"):
-            extract(schema=_Person, model="groq:llama-3.3-70b-versatile", input_file=str(local))
-
-    def test_mistral_sdk_error_is_wrapped_as_model_error(self, tmp_path, mocker):
-        local = tmp_path / "input.txt"
-        local.write_bytes(b"hello")
-        from mistralai.client.errors.sdkerror import SDKError as MistralSDKError
-
-        class _FakeMistralError(MistralSDKError):
-            def __init__(self, message: str):
-                # Bypass SDKError.__init__ to avoid constructing httpx response objects.
-                Exception.__init__(self, message)
-                object.__setattr__(self, "message", message)
-
-        _make_agent_mock(mocker, run_sync_side_effect=_FakeMistralError("rate limited"))
-
-        with pytest.raises(ModelError, match="Model API error"):
-            extract(schema=_Person, model="mistral:mistral-large-latest", input_file=str(local))
+            extract(schema=_Person, model=model_id, input_file=str(local))
 
     def test_message_mentioning_model_is_wrapped_as_extraction_error(self, tmp_path, mocker):
         local = tmp_path / "input.txt"
@@ -1071,8 +1051,6 @@ class TestExtractMany:
     def test_max_concurrency_is_respected(self, tmp_path, mocker):
         files = [str(tmp_path / f"f{i}.txt") for i in range(10)]
         for f in files:
-            from pathlib import Path
-
             Path(f).write_bytes(b"x")
 
         in_flight = 0


### PR DESCRIPTION
- Collapse 9 per-provider try/except blocks in _collect_model_error_types
  into a data-driven loop over (module, attr) tuples
- Add _extraction_errors context manager so the sync and async extraction
  paths share one exception-mapping site instead of inlining the same
  try/except in two places
- Drop redundant `pass` statements after docstrings in exceptions.py
- Parametrize the 8 near-identical "provider error -> ModelError" tests
  into one case-driven test backed by small factory helpers
- Hoist `from pathlib import Path` to the top of test_extract.py

Behavior unchanged. 112 tests pass; coverage remains at 100%.