### PR TITLE
perf: cut cold import 70% and extract_many overhead 95%

### DIFF
--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -1,0 +1,177 @@
+"""Microbenchmarks for openextract local hotspots.
+
+We don't (and can't) benchmark the LLM round-trip itself — that's network +
+inference and dwarfs everything else. What we *can* measure is the local CPU
+work that happens around it on every call: import cost, ``_get_media``,
+agent construction, and the per-call ``load_dotenv`` overhead. Anything we
+shave here compounds across ``extract_many``.
+"""
+
+from __future__ import annotations
+
+import os
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from pydantic import BaseModel
+
+# Stub credentials so pydantic-ai provider clients can be instantiated locally.
+os.environ.setdefault("OPENAI_API_KEY", "sk-bench-dummy")
+os.environ.setdefault("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+
+
+class _Person(BaseModel):
+    name: str
+    age: int
+
+
+def _fmt(seconds: float) -> str:
+    if seconds >= 1:
+        return f"{seconds * 1000:8.2f} ms"
+    if seconds >= 1e-3:
+        return f"{seconds * 1000:8.3f} ms"
+    return f"{seconds * 1e6:8.2f} us"
+
+
+def _bench(label: str, fn, *, iters: int, warmup: int = 1) -> None:
+    for _ in range(warmup):
+        fn()
+    samples = []
+    for _ in range(iters):
+        t0 = time.perf_counter()
+        fn()
+        samples.append(time.perf_counter() - t0)
+    samples.sort()
+    median = statistics.median(samples)
+    p95 = samples[int(0.95 * (len(samples) - 1))]
+    best = samples[0]
+    print(f"  {label:<42} median={_fmt(median)}  p95={_fmt(p95)}  best={_fmt(best)}  (n={iters})")
+
+
+def bench_import_cost() -> None:
+    print("\n[import] cold-start cost of `import openextract` (subprocess)")
+    timings = []
+    for _ in range(5):
+        t0 = time.perf_counter()
+        subprocess.run(
+            [sys.executable, "-c", "import openextract"],
+            check=True,
+            capture_output=True,
+        )
+        timings.append(time.perf_counter() - t0)
+    timings.sort()
+    print(
+        f"  median={_fmt(statistics.median(timings))}  "
+        f"best={_fmt(timings[0])}  worst={_fmt(timings[-1])}"
+    )
+
+
+def bench_get_media(tmp: Path) -> None:
+    from openextract._extract import _get_media, _get_media_type
+
+    small = tmp / "small.txt"
+    small.write_bytes(b"hello world")
+    medium = tmp / "medium.pdf"
+    medium.write_bytes(b"%PDF" + b"x" * 50_000)
+    large = tmp / "large.pdf"
+    large.write_bytes(b"%PDF" + b"x" * 5_000_000)
+
+    print("\n[_get_media] resolving input_file to (bytes, media_type)")
+    _bench("path: small text (~11 B)", lambda: _get_media(str(small)), iters=2000)
+    _bench("path: medium pdf (~50 KB)", lambda: _get_media(str(medium)), iters=1000)
+    _bench("path: large pdf (~5 MB)", lambda: _get_media(str(large)), iters=200)
+
+    raw = b"x" * 100_000
+    _bench(
+        "bytes input (100 KB, just type-check)",
+        lambda: _get_media(raw, media_type="application/pdf"),
+        iters=20000,
+    )
+
+    print("\n[_get_media_type] mimetypes.guess_type")
+    _bench("guess_type('foo.pdf')", lambda: _get_media_type("foo.pdf"), iters=20000)
+
+
+def bench_load_dotenv() -> None:
+    from dotenv import load_dotenv
+
+    print("\n[dotenv] per-call cost of load_dotenv()  (called inside every extract!)")
+    _bench("load_dotenv() (no .env present)", lambda: load_dotenv(), iters=2000)
+
+
+def bench_build_agent() -> None:
+    from openextract._extract import _build_agent
+
+    print("\n[_build_agent] constructing a pydantic_ai.Agent")
+    _bench(
+        "_build_agent(non-ollama)",
+        lambda: _build_agent(_Person, "openai:gpt-5", "extract"),
+        iters=200,
+    )
+    _bench(
+        "_build_agent(ollama)",
+        lambda: _build_agent(_Person, "ollama:llama3", "extract"),
+        iters=200,
+    )
+
+
+def bench_extract_end_to_end(tmp: Path) -> None:
+    """End-to-end extract() with the LLM call mocked out — measures everything
+    *except* the network/inference: dotenv, media read, agent build, dispatch.
+    """
+    from openextract import extract, extract_many
+
+    src = tmp / "doc.pdf"
+    src.write_bytes(b"%PDF" + b"x" * 50_000)
+
+    agent_instance = MagicMock()
+    run_result = MagicMock()
+    run_result.output = _Person(name="Ada", age=36)
+    agent_instance.run_sync.return_value = run_result
+
+    print("\n[extract] sync extract() with Agent mocked (all-local cost per call)")
+    with patch("openextract._extract.Agent", return_value=agent_instance):
+        _bench(
+            "extract(path, openai:gpt-5)",
+            lambda: extract(_Person, "openai:gpt-5", str(src)),
+            iters=500,
+        )
+
+    print("\n[extract_many] 20 inputs, max_concurrency=5, Agent mocked")
+    files = []
+    for i in range(20):
+        p = tmp / f"many_{i}.pdf"
+        p.write_bytes(b"%PDF" + b"x" * 20_000)
+        files.append(str(p))
+
+    async_agent_instance = MagicMock()
+    from unittest.mock import AsyncMock
+
+    async_agent_instance.run = AsyncMock(return_value=run_result)
+    with patch("openextract._extract.Agent", return_value=async_agent_instance):
+        _bench(
+            "extract_many(20 files, conc=5)",
+            lambda: extract_many(_Person, "openai:gpt-5", files, max_concurrency=5),
+            iters=20,
+        )
+
+
+def main() -> int:
+    bench_import_cost()
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        bench_get_media(tmp)
+        bench_load_dotenv()
+        bench_build_agent()
+        bench_extract_end_to_end(tmp)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -39,7 +39,16 @@ def _collect_model_error_types() -> tuple[type[BaseException], ...]:
 
     Each import is guarded so a missing optional provider does not break the
     package. The returned tuple is suitable for use with ``isinstance``.
+
+    Cached after the first call. Deferred (rather than run at module import)
+    because importing every provider SDK eagerly added ~2 s to cold start —
+    ``google.genai`` alone is over a second — and is wasted work unless we
+    actually need to classify an exception.
     """
+    global _MODEL_ERROR_TYPES
+    if _MODEL_ERROR_TYPES is not None:
+        return _MODEL_ERROR_TYPES
+
     error_types: list[type[BaseException]] = []
 
     try:
@@ -106,10 +115,27 @@ def _collect_model_error_types() -> tuple[type[BaseException], ...]:
     except ImportError:  # pragma: no cover - mistral extra is installed
         pass
 
-    return tuple(error_types)
+    _MODEL_ERROR_TYPES = tuple(error_types)
+    return _MODEL_ERROR_TYPES
 
 
-_MODEL_ERROR_TYPES: tuple[type[BaseException], ...] = _collect_model_error_types()
+_MODEL_ERROR_TYPES: tuple[type[BaseException], ...] | None = None
+
+
+_DOTENV_LOADED = False
+
+
+def _ensure_dotenv_loaded() -> None:
+    """Run ``load_dotenv()`` at most once per process.
+
+    Re-scanning the filesystem on every extract added ~50 µs/call and changed
+    nothing — the loaded env vars persist after the first call.
+    """
+    global _DOTENV_LOADED
+    if _DOTENV_LOADED:
+        return
+    load_dotenv()
+    _DOTENV_LOADED = True
 
 
 @dataclass(frozen=True)
@@ -265,7 +291,7 @@ def _map_exception(exc: BaseException) -> ExtractionError:
         return UrlFetchError(f"Failed to fetch URL: {exc}")
     if isinstance(exc, ValidationError):
         return SchemaValidationError(f"Model output did not match schema: {exc}")
-    if isinstance(exc, _MODEL_ERROR_TYPES):
+    if isinstance(exc, _collect_model_error_types()):
         return ModelError(f"Model API error: {exc}")
     return ExtractionError(f"Extraction failed: {exc}")
 
@@ -294,7 +320,7 @@ def _run_extraction(
     ``extract_with_usage`` (which surfaces it).
     """
     try:
-        load_dotenv()
+        _ensure_dotenv_loaded()
         file_bytes, file_type = _get_media(input_file, media_type=media_type)
         agent = _build_agent(schema, model, instructions)
         return agent.run_sync(_build_run_inputs(file_bytes, file_type))
@@ -396,9 +422,31 @@ async def extract_async(
 ) -> T:
     """Async sibling of :func:`extract`; uses ``Agent.run`` instead of ``run_sync``."""
     try:
-        load_dotenv()
+        _ensure_dotenv_loaded()
         file_bytes, file_type = _get_media(input_file, media_type=media_type)
         agent = _build_agent(schema, model, instructions)
+        result = await agent.run(_build_run_inputs(file_bytes, file_type))
+        return result.output
+    except TypeError:
+        raise
+    except ExtractionError:
+        raise
+    except Exception as e:
+        raise _map_exception(e) from e
+
+
+async def _run_with_shared_agent(
+    agent: Agent,
+    input_file: str | bytes | BinaryIO,
+    media_type: str | None,
+) -> object:
+    """Run a single extraction reusing a pre-built ``Agent``.
+
+    Mirrors ``extract_async``'s error mapping so callers get the same
+    ``ExtractionError`` subclasses as the per-item path.
+    """
+    try:
+        file_bytes, file_type = _get_media(input_file, media_type=media_type)
         result = await agent.run(_build_run_inputs(file_bytes, file_type))
         return result.output
     except TypeError:
@@ -418,11 +466,18 @@ async def _gather_extractions(
     return_exceptions: bool,
 ) -> list:
     files = list(input_files)
+    if not files:
+        return []
+    _ensure_dotenv_loaded()
+    # Building the Agent (and its provider HTTP client) is ~32 ms; sharing one
+    # across the batch saves ~32 ms × (N-1) per call. The Agent is stateless
+    # between runs and stays inside this event loop, so this is safe.
+    agent = _build_agent(schema, model, instructions)
     semaphore = asyncio.Semaphore(max_concurrency)
 
     async def _bounded(item):
         async with semaphore:
-            return await extract_async(schema, model, item, instructions)
+            return await _run_with_shared_agent(agent, item, None)
 
     tasks = [_bounded(item) for item in files]
     return await asyncio.gather(*tasks, return_exceptions=return_exceptions)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -29,6 +29,7 @@ from openextract._extract import (
     _get_media_type,
     _is_public_ip,
     _is_safe_host,
+    _run_with_shared_agent,
 )
 
 
@@ -1041,8 +1042,72 @@ class TestExtractAsync:
 
 
 # ---------------------------------------------------------------------------
+# _run_with_shared_agent (per-item runner used by the batch path)
+# ---------------------------------------------------------------------------
+
+
+class TestRunWithSharedAgent:
+    async def test_runs_agent_and_returns_output(self, tmp_path):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hi")
+        expected = _Person(name="Ada", age=36)
+        agent = MagicMock()
+        result = MagicMock()
+        result.output = expected
+        agent.run = AsyncMock(return_value=result)
+
+        out = await _run_with_shared_agent(agent, str(local), None)
+
+        assert out is expected
+        agent.run.assert_awaited_once()
+
+    async def test_type_error_propagates_unchanged(self):
+        """bytes without media_type must raise TypeError, not ExtractionError."""
+        agent = MagicMock()
+        agent.run = AsyncMock()
+
+        with pytest.raises(TypeError, match="media_type is required"):
+            await _run_with_shared_agent(agent, b"abc", None)
+        agent.run.assert_not_awaited()
+
+    async def test_existing_extraction_error_passes_through(self, tmp_path):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hi")
+        original = SchemaValidationError("already mapped")
+        agent = MagicMock()
+        agent.run = AsyncMock(side_effect=original)
+
+        with pytest.raises(SchemaValidationError) as exc_info:
+            await _run_with_shared_agent(agent, str(local), None)
+        assert exc_info.value is original
+
+    async def test_generic_exception_is_wrapped(self, tmp_path):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hi")
+        agent = MagicMock()
+        agent.run = AsyncMock(side_effect=RuntimeError("kaboom"))
+
+        with pytest.raises(ExtractionError, match="Extraction failed: kaboom"):
+            await _run_with_shared_agent(agent, str(local), None)
+
+
+# ---------------------------------------------------------------------------
 # extract_many
 # ---------------------------------------------------------------------------
+
+
+def _stub_shared_agent(mocker, side_effect):
+    """Stub the batch-path agent build + per-item runner used by extract_many.
+
+    extract_many now builds a single Agent and reuses it across items via
+    ``_run_with_shared_agent``. Tests just need a no-op Agent and to drive
+    per-item behavior through the runner.
+    """
+    mocker.patch("openextract._extract._build_agent", return_value=MagicMock())
+    mocker.patch(
+        "openextract._extract._run_with_shared_agent",
+        side_effect=side_effect,
+    )
 
 
 class TestExtractMany:
@@ -1054,15 +1119,14 @@ class TestExtractMany:
             files.append(str(p))
 
         people = [_Person(name=f"n{i}", age=i) for i in range(4)]
-        # Map each path to its expected person via side_effect.
         path_to_person = dict(zip(files, people, strict=True))
 
-        async def fake_extract_async(schema, model, input_file, instructions=None):
+        async def fake_run(agent, input_file, media_type):
             # Tiny await yields control so tasks can interleave.
             await asyncio.sleep(0)
             return path_to_person[input_file]
 
-        mocker.patch("openextract._extract.extract_async", side_effect=fake_extract_async)
+        _stub_shared_agent(mocker, fake_run)
 
         results = extract_many(schema=_Person, model="openai:gpt-5", input_files=files)
 
@@ -1079,7 +1143,7 @@ class TestExtractMany:
         peak = 0
         lock = asyncio.Lock()
 
-        async def fake_extract_async(schema, model, input_file, instructions=None):
+        async def fake_run(agent, input_file, media_type):
             nonlocal in_flight, peak
             async with lock:
                 in_flight += 1
@@ -1089,7 +1153,7 @@ class TestExtractMany:
                 in_flight -= 1
             return _Person(name=input_file, age=1)
 
-        mocker.patch("openextract._extract.extract_async", side_effect=fake_extract_async)
+        _stub_shared_agent(mocker, fake_run)
 
         results = extract_many(
             schema=_Person,
@@ -1105,13 +1169,13 @@ class TestExtractMany:
     def test_fail_fast_propagates_first_error(self, tmp_path, mocker):
         files = [str(tmp_path / f"f{i}.txt") for i in range(3)]
 
-        async def fake_extract_async(schema, model, input_file, instructions=None):
+        async def fake_run(agent, input_file, media_type):
             if input_file.endswith("f1.txt"):
                 raise ModelError("boom on f1")
             await asyncio.sleep(0.01)
             return _Person(name=input_file, age=1)
 
-        mocker.patch("openextract._extract.extract_async", side_effect=fake_extract_async)
+        _stub_shared_agent(mocker, fake_run)
 
         with pytest.raises(ModelError, match="boom on f1"):
             extract_many(schema=_Person, model="openai:gpt-5", input_files=files)
@@ -1119,12 +1183,12 @@ class TestExtractMany:
     def test_return_exceptions_yields_mixed_list(self, tmp_path, mocker):
         files = [str(tmp_path / f"f{i}.txt") for i in range(3)]
 
-        async def fake_extract_async(schema, model, input_file, instructions=None):
+        async def fake_run(agent, input_file, media_type):
             if input_file.endswith("f1.txt"):
                 raise ModelError("boom on f1")
             return _Person(name=input_file, age=1)
 
-        mocker.patch("openextract._extract.extract_async", side_effect=fake_extract_async)
+        _stub_shared_agent(mocker, fake_run)
 
         results = extract_many(
             schema=_Person,
@@ -1137,6 +1201,25 @@ class TestExtractMany:
         assert isinstance(results[1], ModelError)
         assert isinstance(results[2], _Person)
 
+    def test_agent_is_built_once_per_batch(self, tmp_path, mocker):
+        """The whole point of the batch path: one Agent for N items."""
+        files = [str(tmp_path / f"f{i}.txt") for i in range(8)]
+
+        async def fake_run(agent, input_file, media_type):
+            return _Person(name=input_file, age=1)
+
+        build_mock = mocker.patch("openextract._extract._build_agent", return_value=MagicMock())
+        mocker.patch("openextract._extract._run_with_shared_agent", side_effect=fake_run)
+
+        extract_many(schema=_Person, model="openai:gpt-5", input_files=files)
+
+        assert build_mock.call_count == 1
+
+    def test_empty_input_returns_empty_list_without_building_agent(self, mocker):
+        build_mock = mocker.patch("openextract._extract._build_agent")
+        assert extract_many(schema=_Person, model="openai:gpt-5", input_files=[]) == []
+        build_mock.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # extract_many_async
@@ -1147,13 +1230,13 @@ class TestExtractManyAsync:
     async def test_fail_fast_propagates_first_error(self, tmp_path, mocker):
         files = [str(tmp_path / f"f{i}.txt") for i in range(3)]
 
-        async def fake_extract_async(schema, model, input_file, instructions=None):
+        async def fake_run(agent, input_file, media_type):
             if input_file.endswith("f0.txt"):
                 raise ModelError("boom first")
             await asyncio.sleep(0.01)
             return _Person(name=input_file, age=1)
 
-        mocker.patch("openextract._extract.extract_async", side_effect=fake_extract_async)
+        _stub_shared_agent(mocker, fake_run)
 
         with pytest.raises(ModelError, match="boom first"):
             await extract_many_async(
@@ -1165,12 +1248,12 @@ class TestExtractManyAsync:
     async def test_return_exceptions_yields_mixed_list(self, tmp_path, mocker):
         files = [str(tmp_path / f"f{i}.txt") for i in range(3)]
 
-        async def fake_extract_async(schema, model, input_file, instructions=None):
+        async def fake_run(agent, input_file, media_type):
             if input_file.endswith("f1.txt"):
                 raise SchemaValidationError("bad schema")
             return _Person(name=input_file, age=1)
 
-        mocker.patch("openextract._extract.extract_async", side_effect=fake_extract_async)
+        _stub_shared_agent(mocker, fake_run)
 
         results = await extract_many_async(
             schema=_Person,
@@ -1188,11 +1271,11 @@ class TestExtractManyAsync:
         expected = [_Person(name=f, age=i) for i, f in enumerate(files)]
         mapping = dict(zip(files, expected, strict=True))
 
-        async def fake_extract_async(schema, model, input_file, instructions=None):
+        async def fake_run(agent, input_file, media_type):
             await asyncio.sleep(0)
             return mapping[input_file]
 
-        mocker.patch("openextract._extract.extract_async", side_effect=fake_extract_async)
+        _stub_shared_agent(mocker, fake_run)
 
         results = await extract_many_async(
             schema=_Person,


### PR DESCRIPTION
Three local hotspots were eating per-call time. Microbenchmark (scripts/bench.py)
before/after on Python 3.12:

  cold import openextract           3315 ms  ->   976 ms   (-70%)
  extract_many(20 files, conc=5)*    654 ms  ->    34 ms   (-95%)
  extract() dispatch overhead*       168 us  ->    88 us   (-48%)
  *all-local cost; LLM call mocked.

Changes:

1. Lazy provider-error imports. _collect_model_error_types() eagerly imported
   every provider SDK (google.genai alone was 1.07 s, anthropic 439 ms, openai
   401 ms) just to build an isinstance tuple. Now it runs the first time we
   map an exception, and the result is cached for the process.

2. Share Agent within extract_many batches. Building a pydantic_ai.Agent
   instantiates a provider HTTP client (~32 ms). The batch path now builds
   one Agent and reuses it across all N items via _run_with_shared_agent,
   instead of one Agent per item. Stays inside a single event loop so no
   cross-loop client issues; per-call extract() still constructs fresh.

3. Memoize load_dotenv(). It was re-scanning the filesystem on every
   extract call (~50 us) for zero behavioral benefit -- env vars persist.

100% coverage maintained; 118 tests pass.

https://claude.ai/code/session_01HbYWRQ6k7bD6usnRpdaRZ7