### PR TITLE
release: v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+
+## [0.7.0] - 2026-05-22
+### Added
+- Add `extract_with_usage_async`: async counterpart to `extract_with_usage` that
+  returns `(output, Usage)` alongside the token counts for the model call.
+- Add `media_type` keyword argument to `extract_many` and `extract_many_async`:
+  the batch functions previously hard-coded `None`, making it impossible to process
+  `bytes` or file-like inputs that require an explicit MIME type; the new parameter
+  is applied uniformly to every item in the batch.
+- Add `--max-retries` and `--retry-backoff` flags to the `openextract` CLI:
+  exposes the existing retry logic (already available via the Python API) to
+  command-line users.
+
 ### Security
 - URL fetching now refuses hosts that resolve to non-public addresses
   (private/loopback/link-local/multicast/reserved, IPv4 and IPv6, including
@@ -65,7 +78,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.1.1] - 2025-09-10
 - Merge pull request #12 from Mellow-Artificial-Intelligence/new-release.
 
-[Unreleased]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.3.2...v0.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openextract"
-version = "0.6.0"
+version = "0.7.0"
 description = "Extract structured data from documents, images, audio, and video using LLMs"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/openextract/__init__.py
+++ b/src/openextract/__init__.py
@@ -9,6 +9,7 @@ from ._extract import (
     extract_many,
     extract_many_async,
     extract_with_usage,
+    extract_with_usage_async,
 )
 from .exceptions import ExtractionError, ModelError, SchemaValidationError, UrlFetchError
 
@@ -18,6 +19,7 @@ __all__ = [
     "extract_many",
     "extract_many_async",
     "extract_with_usage",
+    "extract_with_usage_async",
     "Usage",
     "ExtractionError",
     "ModelError",

--- a/src/openextract/_cli.py
+++ b/src/openextract/_cli.py
@@ -68,6 +68,20 @@ def _build_parser() -> argparse.ArgumentParser:
         default="json",
         help="Output format: 'json' (default) prints model_dump_json; 'repr' prints repr().",
     )
+    parser.add_argument(
+        "--max-retries",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Retry up to N times on ModelError with exponential backoff (default 0).",
+    )
+    parser.add_argument(
+        "--retry-backoff",
+        type=float,
+        default=1.0,
+        metavar="SECONDS",
+        help="Base backoff in seconds for retry (default 1.0).",
+    )
     return parser
 
 
@@ -88,6 +102,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             model=args.model,
             input_file=args.input_file,
             instructions=args.instructions,
+            max_retries=args.max_retries,
+            retry_backoff=args.retry_backoff,
         )
     except UrlFetchError as exc:
         print(f"error: {exc}", file=sys.stderr)

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -392,6 +392,21 @@ def extract_with_usage(
     return result.output, _usage_from_result(result)
 
 
+async def extract_with_usage_async(
+    schema: type[T],
+    model: str,
+    input_file: str | bytes | BinaryIO,
+    instructions: str | None = None,
+    *,
+    media_type: str | None = None,
+) -> tuple[T, Usage]:
+    """Async sibling of :func:`extract_with_usage`; returns ``(output, Usage)``."""
+    with _extraction_errors():
+        agent, inputs = _prepare_run(schema, model, input_file, instructions, media_type)
+        result = await agent.run(inputs)
+        return result.output, _usage_from_result(result)
+
+
 async def extract_async(
     schema: type[T],
     model: str,
@@ -430,6 +445,7 @@ async def _gather_extractions(
     instructions: str | None,
     max_concurrency: int,
     return_exceptions: bool,
+    media_type: str | None,
 ) -> list:
     files = list(input_files)
     if not files:
@@ -443,7 +459,7 @@ async def _gather_extractions(
 
     async def _bounded(item):
         async with semaphore:
-            return await _run_with_shared_agent(agent, item, None)
+            return await _run_with_shared_agent(agent, item, media_type)
 
     tasks = [_bounded(item) for item in files]
     return await asyncio.gather(*tasks, return_exceptions=return_exceptions)
@@ -455,6 +471,7 @@ def extract_many(
     input_files: Iterable[str | bytes | BinaryIO],
     instructions: str | None = None,
     *,
+    media_type: str | None = None,
     max_concurrency: int = 5,
     return_exceptions: bool = False,
 ) -> list:
@@ -465,6 +482,9 @@ def extract_many(
         model: The model identifier.
         input_files: Iterable of paths, URLs, or already-resolved bytes.
         instructions: Optional natural-language guidance.
+        media_type: Optional MIME type applied uniformly to every item.  Required
+            when ``input_files`` contains ``bytes`` or file-like objects; optional
+            override for path/URL items.
         max_concurrency: Maximum number of in-flight extractions.
         return_exceptions: If True, exceptions are returned in-place instead of raised
             (mirrors :func:`asyncio.gather`).
@@ -480,6 +500,7 @@ def extract_many(
             instructions,
             max_concurrency,
             return_exceptions,
+            media_type,
         )
     )
 
@@ -490,6 +511,7 @@ async def extract_many_async(
     input_files: Iterable[str | bytes | BinaryIO],
     instructions: str | None = None,
     *,
+    media_type: str | None = None,
     max_concurrency: int = 5,
     return_exceptions: bool = False,
 ) -> list:
@@ -501,4 +523,5 @@ async def extract_many_async(
         instructions,
         max_concurrency,
         return_exceptions,
+        media_type,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -142,6 +142,8 @@ class TestMainSuccess:
             model="openai:gpt-5",
             input_file="input.txt",
             instructions="find the person",
+            max_retries=0,
+            retry_backoff=1.0,
         )
         captured = capsys.readouterr()
         assert '"name": "Ada"' in captured.out
@@ -184,6 +186,46 @@ class TestMainSuccess:
 
         assert exit_code == 0
         assert mock_extract.call_args.kwargs["instructions"] is None
+
+    def test_max_retries_and_retry_backoff_defaults(self, mocker):
+        fake = MagicMock()
+        fake.model_dump_json.return_value = "{}"
+        mock_extract = _patch_extract(mocker, return_value=fake)
+
+        main(
+            [
+                "input.txt",
+                "--schema",
+                "tests.test_cli:_FixtureSchema",
+                "--model",
+                "openai:gpt-5",
+            ]
+        )
+
+        assert mock_extract.call_args.kwargs["max_retries"] == 0
+        assert mock_extract.call_args.kwargs["retry_backoff"] == 1.0
+
+    def test_max_retries_and_retry_backoff_custom(self, mocker):
+        fake = MagicMock()
+        fake.model_dump_json.return_value = "{}"
+        mock_extract = _patch_extract(mocker, return_value=fake)
+
+        main(
+            [
+                "input.txt",
+                "--schema",
+                "tests.test_cli:_FixtureSchema",
+                "--model",
+                "openai:gpt-5",
+                "--max-retries",
+                "3",
+                "--retry-backoff",
+                "2.5",
+            ]
+        )
+
+        assert mock_extract.call_args.kwargs["max_retries"] == 3
+        assert mock_extract.call_args.kwargs["retry_backoff"] == 2.5
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1080,9 +1080,7 @@ class TestExtractWithUsageAsync:
         _make_async_agent_mock(mocker, output=_Person(name="x", age=1))
 
         with pytest.raises(TypeError, match="media_type is required"):
-            await extract_with_usage_async(
-                schema=_Person, model="openai:gpt-5", input_file=b"abc"
-            )
+            await extract_with_usage_async(schema=_Person, model="openai:gpt-5", input_file=b"abc")
 
 
 # ---------------------------------------------------------------------------
@@ -1267,6 +1265,7 @@ class TestExtractMany:
         files = [str(tmp_path / f"f{i}.txt") for i in range(2)]
         for f in files:
             from pathlib import Path
+
             Path(f).write_bytes(b"x")
 
         received_types: list[str | None] = []

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -23,6 +23,7 @@ from openextract import (
     extract_many,
     extract_many_async,
     extract_with_usage,
+    extract_with_usage_async,
 )
 from openextract._extract import (
     _fetch_url,
@@ -73,6 +74,7 @@ def test_star_import_exposes_only_existing_names():
         "extract_many",
         "extract_many_async",
         "extract_with_usage",
+        "extract_with_usage_async",
         "Usage",
         "ExtractionError",
         "ModelError",
@@ -904,7 +906,7 @@ class TestExtractRetry:
 # ---------------------------------------------------------------------------
 
 
-def _make_async_agent_mock(mocker, output=None, run_side_effect=None):
+def _make_async_agent_mock(mocker, output=None, run_side_effect=None, usage=None):
     """Patch openextract._extract.Agent and stub the async ``run`` method."""
     agent_instance = MagicMock()
     if run_side_effect is not None:
@@ -912,6 +914,8 @@ def _make_async_agent_mock(mocker, output=None, run_side_effect=None):
     else:
         run_result = MagicMock()
         run_result.output = output
+        if usage is not None:
+            run_result.usage.return_value = usage
         agent_instance.run = AsyncMock(return_value=run_result)
     agent_cls = mocker.patch("openextract._extract.Agent", return_value=agent_instance)
     return agent_cls, agent_instance
@@ -1019,6 +1023,66 @@ class TestExtractAsync:
         with pytest.raises(SchemaValidationError) as exc_info:
             await extract_async(schema=_Person, model="openai:gpt-5", input_file=str(local))
         assert exc_info.value is original
+
+
+# ---------------------------------------------------------------------------
+# extract_with_usage_async
+# ---------------------------------------------------------------------------
+
+
+class TestExtractWithUsageAsync:
+    async def test_returns_output_and_usage_tuple(self, tmp_path, mocker):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hello")
+        expected = _Person(name="Ada", age=36)
+        usage_obj = MagicMock(input_tokens=10, output_tokens=20, total_tokens=30)
+        _make_async_agent_mock(mocker, output=expected, usage=usage_obj)
+
+        output, usage = await extract_with_usage_async(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_file=str(local),
+            instructions="pull the person",
+        )
+
+        assert output is expected
+        assert usage == Usage(input_tokens=10, output_tokens=20, total_tokens=30)
+
+    async def test_missing_usage_fields_default_to_zero(self, tmp_path, mocker):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hello")
+        expected = _Person(name="Linus", age=54)
+
+        class _BareUsage:
+            pass
+
+        _make_async_agent_mock(mocker, output=expected, usage=_BareUsage())
+
+        _, usage = await extract_with_usage_async(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_file=str(local),
+        )
+
+        assert usage == Usage(input_tokens=0, output_tokens=0, total_tokens=0)
+
+    async def test_propagates_runtime_error_as_extraction_error(self, tmp_path, mocker):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hello")
+        _make_async_agent_mock(mocker, run_side_effect=RuntimeError("kaboom"))
+
+        with pytest.raises(ExtractionError, match="Extraction failed: kaboom"):
+            await extract_with_usage_async(
+                schema=_Person, model="openai:gpt-5", input_file=str(local)
+            )
+
+    async def test_missing_media_type_for_bytes_raises_type_error(self, mocker):
+        _make_async_agent_mock(mocker, output=_Person(name="x", age=1))
+
+        with pytest.raises(TypeError, match="media_type is required"):
+            await extract_with_usage_async(
+                schema=_Person, model="openai:gpt-5", input_file=b"abc"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -1197,6 +1261,31 @@ class TestExtractMany:
         build_mock = mocker.patch("openextract._extract._build_agent")
         assert extract_many(schema=_Person, model="openai:gpt-5", input_files=[]) == []
         build_mock.assert_not_called()
+
+    def test_media_type_forwarded_to_runner(self, tmp_path, mocker):
+        """media_type kwarg is passed through to every per-item runner call."""
+        files = [str(tmp_path / f"f{i}.txt") for i in range(2)]
+        for f in files:
+            from pathlib import Path
+            Path(f).write_bytes(b"x")
+
+        received_types: list[str | None] = []
+
+        async def fake_run(agent, input_file, media_type):
+            received_types.append(media_type)
+            return _Person(name=input_file, age=1)
+
+        _stub_shared_agent(mocker, fake_run)
+
+        extract_many(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_files=files,
+            media_type="application/pdf",
+        )
+
+        assert all(mt == "application/pdf" for mt in received_types)
+        assert len(received_types) == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **`extract_with_usage_async`**: adds the missing async counterpart to `extract_with_usage`, returning `(output, Usage)` with token counts for the model call. `extract_async` existed but silently discarded usage data.
- **`media_type` param for `extract_many` / `extract_many_async`**: the batch functions previously hard-coded `None` for the per-item media type, making it impossible to process `bytes` or file-like inputs that require an explicit MIME type. The new uniform `media_type` kwarg is forwarded to every item in the batch.
- **`--max-retries` / `--retry-backoff` CLI flags**: exposes the existing retry logic (already available via the Python API since v0.5.0) to command-line users.
- Promotes the previously-unreleased SSRF defenses and GitHub Actions SHA-pinning into v0.7.0.

## Test plan

- [ ] All 125 tests pass (`uv run pytest tests/ -q`)
- [ ] 100% branch coverage maintained (`--cov` confirms `Total coverage: 100.00%`)
- [ ] `extract_with_usage_async` tested: output+usage tuple, missing fields → zero, TypeError for bytes without media_type, error propagation
- [ ] `extract_many` `media_type` forwarding tested: assert runner receives the specified MIME type for every item
- [ ] CLI retry flags tested: default values (0, 1.0) and custom values passed through to `extract()`

https://claude.ai/code/session_01XQrnhVmnC4ZsHUm8JMPVWp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQrnhVmnC4ZsHUm8JMPVWp)_