### PR TITLE
release: v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-29
+### Added
+- `Usage` now supports addition: `u1 + u2` returns a new `Usage` with summed
+  token fields, and `sum(usages)` works without a custom start value (Python's
+  built-in `sum()` seeds with integer `0`, which `__radd__` handles).
+- `extract_async` now accepts `max_retries` and `retry_backoff` keyword
+  arguments, matching the retry behaviour of `extract()`. Uses
+  `asyncio.sleep` between attempts so the event loop is not blocked.
+- `openextract --version` prints the installed package version and exits 0.
+
 ## [0.7.0] - 2026-05-22
 ### Added
 - Add `extract_with_usage_async`: async counterpart to `extract_with_usage` that
@@ -78,7 +88,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.1.1] - 2025-09-10
 - Merge pull request #12 from Mellow-Artificial-Intelligence/new-release.
 
-[Unreleased]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.4.0...v0.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openextract"
-version = "0.7.0"
+version = "0.8.0"
 description = "Extract structured data from documents, images, audio, and video using LLMs"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/openextract/_cli.py
+++ b/src/openextract/_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import importlib
+import importlib.metadata
 import sys
 from collections.abc import Sequence
 
@@ -42,6 +43,11 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="openextract",
         description="Extract structured data from a file or URL using an LLM.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {importlib.metadata.version('openextract')}",
     )
     parser.add_argument(
         "input_file",

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -104,6 +104,20 @@ class Usage:
     output_tokens: int
     total_tokens: int
 
+    def __add__(self, other: object) -> "Usage":
+        if not isinstance(other, Usage):
+            return NotImplemented  # type: ignore[return-value]
+        return Usage(
+            input_tokens=self.input_tokens + other.input_tokens,
+            output_tokens=self.output_tokens + other.output_tokens,
+            total_tokens=self.total_tokens + other.total_tokens,
+        )
+
+    def __radd__(self, other: object) -> "Usage":
+        if isinstance(other, int) and other == 0:
+            return self
+        return NotImplemented  # type: ignore[return-value]
+
 
 def _get_media_type(file_path: str) -> str:
     """Return the MIME type for a file path (e.g. 'application/pdf')."""
@@ -414,12 +428,33 @@ async def extract_async(
     instructions: str | None = None,
     *,
     media_type: str | None = None,
+    max_retries: int = 0,
+    retry_backoff: float = 1.0,
 ) -> T:
-    """Async sibling of :func:`extract`; uses ``Agent.run`` instead of ``run_sync``."""
-    with _extraction_errors():
-        agent, inputs = _prepare_run(schema, model, input_file, instructions, media_type)
-        result = await agent.run(inputs)
-        return result.output
+    """Async sibling of :func:`extract`; uses ``Agent.run`` with optional retry.
+
+    Args:
+        schema: A Pydantic model class defining the expected output structure.
+        model: The model identifier.
+        input_file: A local file path, URL, raw bytes, or binary file-like object.
+        instructions: Optional natural-language guidance for the LLM.
+        media_type: Optional MIME type.
+        max_retries: Retry up to this many additional times on ``ModelError``.
+        retry_backoff: Base backoff in seconds (exponential with up to 25% jitter).
+    """
+    attempt = 0
+    while True:
+        try:
+            with _extraction_errors():
+                agent, inputs = _prepare_run(schema, model, input_file, instructions, media_type)
+                result = await agent.run(inputs)
+                return result.output
+        except ModelError:
+            if attempt >= max_retries:
+                raise
+            delay = retry_backoff * (2**attempt) * (1 + random.uniform(0, 0.25))
+            await asyncio.sleep(delay)
+            attempt += 1
 
 
 async def _run_with_shared_agent(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for openextract._cli."""
 
+import importlib.metadata
 from unittest.mock import MagicMock
 
 import pytest
@@ -110,6 +111,14 @@ class TestArgparse:
         assert exc_info.value.code != 0
         captured = capsys.readouterr()
         assert "output" in captured.err.lower()
+
+    def test_version_flag_prints_version_and_exits_zero(self, capsys):
+        expected_version = importlib.metadata.version("openextract")
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--version"])
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert expected_version in captured.out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1350,3 +1350,152 @@ class TestExtractManyAsync:
         )
 
         assert results == expected
+
+
+# ---------------------------------------------------------------------------
+# Usage arithmetic
+# ---------------------------------------------------------------------------
+
+
+class TestUsageArithmetic:
+    def test_add_two_usages(self):
+        u1 = Usage(input_tokens=10, output_tokens=20, total_tokens=30)
+        u2 = Usage(input_tokens=5, output_tokens=8, total_tokens=13)
+        result = u1 + u2
+        assert result == Usage(input_tokens=15, output_tokens=28, total_tokens=43)
+
+    def test_add_returns_new_instance(self):
+        u1 = Usage(input_tokens=10, output_tokens=20, total_tokens=30)
+        u2 = Usage(input_tokens=5, output_tokens=8, total_tokens=13)
+        result = u1 + u2
+        assert result is not u1
+        assert result is not u2
+
+    def test_sum_of_usages(self):
+        usages = [
+            Usage(input_tokens=10, output_tokens=20, total_tokens=30),
+            Usage(input_tokens=5, output_tokens=8, total_tokens=13),
+            Usage(input_tokens=1, output_tokens=2, total_tokens=3),
+        ]
+        total = sum(usages)
+        assert total == Usage(input_tokens=16, output_tokens=30, total_tokens=46)
+
+    def test_add_non_usage_returns_not_implemented(self):
+        u = Usage(input_tokens=1, output_tokens=2, total_tokens=3)
+        assert u.__add__(42) is NotImplemented
+
+    def test_radd_from_zero_returns_self(self):
+        u = Usage(input_tokens=5, output_tokens=10, total_tokens=15)
+        result = u.__radd__(0)
+        assert result is u
+
+    def test_radd_non_zero_returns_not_implemented(self):
+        u = Usage(input_tokens=1, output_tokens=2, total_tokens=3)
+        assert u.__radd__(42) is NotImplemented
+
+
+# ---------------------------------------------------------------------------
+# extract_async retry behavior
+# ---------------------------------------------------------------------------
+
+
+class TestExtractAsyncRetry:
+    async def test_no_retry_by_default_raises_immediately(self, tmp_path, mocker):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hi")
+        sleep_mock = mocker.patch("openextract._extract.asyncio.sleep")
+        agent_instance = MagicMock()
+        agent_instance.run = AsyncMock(side_effect=ModelError("upstream down"))
+        mocker.patch("openextract._extract.Agent", return_value=agent_instance)
+
+        with pytest.raises(ModelError, match="upstream down"):
+            await extract_async(schema=_Person, model="openai:gpt-5", input_file=str(local))
+
+        assert agent_instance.run.await_count == 1
+        sleep_mock.assert_not_called()
+
+    async def test_retry_succeeds_after_transient_model_errors(self, tmp_path, mocker):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hi")
+        sleep_mock = mocker.patch("openextract._extract.asyncio.sleep")
+        expected = _Person(name="Grace", age=85)
+        success_result = MagicMock()
+        success_result.output = expected
+        agent_instance = MagicMock()
+        agent_instance.run = AsyncMock(
+            side_effect=[ModelError("flaky"), ModelError("flaky"), success_result]
+        )
+        mocker.patch("openextract._extract.Agent", return_value=agent_instance)
+
+        result = await extract_async(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_file=str(local),
+            max_retries=2,
+        )
+
+        assert result is expected
+        assert agent_instance.run.await_count == 3
+        assert sleep_mock.await_count == 2
+
+    async def test_retry_exhausted_raises_last_model_error(self, tmp_path, mocker):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hi")
+        sleep_mock = mocker.patch("openextract._extract.asyncio.sleep")
+        agent_instance = MagicMock()
+        agent_instance.run = AsyncMock(side_effect=ModelError("persistent"))
+        mocker.patch("openextract._extract.Agent", return_value=agent_instance)
+
+        with pytest.raises(ModelError, match="persistent"):
+            await extract_async(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_file=str(local),
+                max_retries=2,
+            )
+
+        assert agent_instance.run.await_count == 3
+        assert sleep_mock.await_count == 2
+
+    async def test_backoff_schedule_uses_exponential_jitter(self, tmp_path, mocker):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hi")
+        sleep_mock = mocker.patch("openextract._extract.asyncio.sleep")
+        agent_instance = MagicMock()
+        agent_instance.run = AsyncMock(side_effect=ModelError("nope"))
+        mocker.patch("openextract._extract.Agent", return_value=agent_instance)
+
+        with pytest.raises(ModelError):
+            await extract_async(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_file=str(local),
+                max_retries=3,
+                retry_backoff=1.0,
+            )
+
+        delays = [call.args[0] for call in sleep_mock.call_args_list]
+        assert len(delays) == 3
+        assert delays == sorted(delays)
+        assert 1.0 <= delays[0] <= 1.25
+        assert 2.0 <= delays[1] <= 2.5
+        assert 4.0 <= delays[2] <= 5.0
+
+    async def test_schema_validation_error_is_not_retried(self, tmp_path, mocker):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hi")
+        sleep_mock = mocker.patch("openextract._extract.asyncio.sleep")
+        agent_instance = MagicMock()
+        agent_instance.run = AsyncMock(side_effect=SchemaValidationError("bad shape"))
+        mocker.patch("openextract._extract.Agent", return_value=agent_instance)
+
+        with pytest.raises(SchemaValidationError, match="bad shape"):
+            await extract_async(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_file=str(local),
+                max_retries=3,
+            )
+
+        assert agent_instance.run.await_count == 1
+        sleep_mock.assert_not_called()


### PR DESCRIPTION
## Summary

Three improvements shipped in this release:

- **`Usage` arithmetic** — `u1 + u2` returns a new `Usage` with summed token fields; `sum(usages)` works without a custom start value because `__radd__` handles Python's integer `0` seed. Callers aggregating token counts from batch results no longer need manual loops.
- **`extract_async` retry** — adds `max_retries` and `retry_backoff` keyword arguments to match the sync `extract()` API. Uses `asyncio.sleep` between attempts so the event loop is not blocked. Previously the async path had no retry support at all.
- **`--version` CLI flag** — `openextract --version` prints the installed package version and exits 0, following standard CLI conventions.

## Test plan

- [ ] All tests pass (`uv run pytest tests/ -q`)
- [ ] 100% branch coverage maintained (`--cov` confirms `Total coverage: 100.00%`)
- [ ] `TestUsageArithmetic`: `u1 + u2`, `sum([u1, u2, u3])`, `NotImplemented` for non-Usage operands
- [ ] `TestExtractAsyncRetry`: no retry by default, retry success after transient errors, exhaustion raises, exponential jitter schedule, non-`ModelError` not retried
- [ ] `TestArgparse.test_version_flag_prints_version_and_exits_zero`: `--version` output matches installed version

https://claude.ai/code/session_01GvNcrxm8nogSDQcS1c4box

---
_Generated by [Claude Code](https://claude.ai/code/session_01GvNcrxm8nogSDQcS1c4box)_