### PR TITLE
feat: configurable URL fetch timeout and redirect limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Environment variables `OPENEXTRACT_URL_TIMEOUT` and `OPENEXTRACT_MAX_REDIRECTS`
+  to configure HTTP timeout and redirect limits when fetching URLs.
+
 ### Changed
 - Expand README API reference to document `extract_async`, `extract_many`,
   `extract_with_usage`, and related public APIs.

--- a/README.md
+++ b/README.md
@@ -286,7 +286,14 @@ attacker cannot use a public URL that redirects to an internal one.
 For workflows that legitimately need to fetch internal URLs (testing
 against `localhost`, on-prem services, etc.), set the
 `OPENEXTRACT_ALLOW_PRIVATE_URLS` environment variable to `1`, `true`, or
-`yes` to disable the check. If you need a one-off fetch from an internal
+`yes` to disable the check.
+
+Tune fetch behavior with:
+
+- `OPENEXTRACT_URL_TIMEOUT` &mdash; HTTP timeout in seconds (default `30`)
+- `OPENEXTRACT_MAX_REDIRECTS` &mdash; maximum redirect hops (default `10`)
+
+Invalid or non-positive values fall back to the defaults. If you need a one-off fetch from an internal
 host without disabling validation globally, fetch the bytes with your own
 HTTP client and pass them to `extract()` as `bytes`/file-like with an
 explicit `media_type`.

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -27,8 +27,10 @@ T = TypeVar("T", bound=BaseModel)
 
 _DEFAULT_MEDIA_TYPE = "application/octet-stream"
 _URL_PREFIXES = ("http://", "https://")
-_URL_FETCH_TIMEOUT = 30.0
-_MAX_REDIRECTS = 10
+_DEFAULT_URL_FETCH_TIMEOUT = 30.0
+_DEFAULT_MAX_REDIRECTS = 10
+_URL_TIMEOUT_ENV = "OPENEXTRACT_URL_TIMEOUT"
+_MAX_REDIRECTS_ENV = "OPENEXTRACT_MAX_REDIRECTS"
 _ALLOW_PRIVATE_URLS_ENV = "OPENEXTRACT_ALLOW_PRIVATE_URLS"
 _BYTES_MEDIA_TYPE_REQUIRED = (
     "media_type is required when input_file is bytes or a file-like object; "
@@ -116,6 +118,40 @@ def _allow_private_urls() -> bool:
     return os.environ.get(_ALLOW_PRIVATE_URLS_ENV, "").lower() in ("1", "true", "yes")
 
 
+def _env_positive_float(name: str, default: float) -> float:
+    """Parse a positive float from ``name``; return ``default`` when unset or invalid."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _env_positive_int(name: str, default: int) -> int:
+    """Parse a positive int from ``name``; return ``default`` when unset or invalid."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _url_fetch_timeout() -> float:
+    """HTTP timeout in seconds for URL fetches (``OPENEXTRACT_URL_TIMEOUT``)."""
+    return _env_positive_float(_URL_TIMEOUT_ENV, _DEFAULT_URL_FETCH_TIMEOUT)
+
+
+def _max_redirects() -> int:
+    """Maximum redirect hops when fetching URLs (``OPENEXTRACT_MAX_REDIRECTS``)."""
+    return _env_positive_int(_MAX_REDIRECTS_ENV, _DEFAULT_MAX_REDIRECTS)
+
+
 def _is_public_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     """Return True only for globally routable public unicast addresses.
 
@@ -163,11 +199,13 @@ def _is_safe_host(host: str | None) -> bool:
 def _fetch_url(url: str) -> httpx.Response:
     """Fetch ``url`` with SSRF defenses; validate the host at every redirect hop."""
     current = url
-    for _ in range(_MAX_REDIRECTS):
+    limit = _max_redirects()
+    timeout = _url_fetch_timeout()
+    for _ in range(limit):
         host = urlparse(current).hostname
         if not _is_safe_host(host):
             raise UrlFetchError(f"Refusing to fetch URL with non-public host: {host!r}")
-        response = httpx.get(current, follow_redirects=False, timeout=_URL_FETCH_TIMEOUT)
+        response = httpx.get(current, follow_redirects=False, timeout=timeout)
         if response.is_redirect:
             location = response.headers.get("location")
             if not location:
@@ -176,7 +214,7 @@ def _fetch_url(url: str) -> httpx.Response:
             continue
         response.raise_for_status()
         return response
-    raise UrlFetchError(f"Too many redirects (>{_MAX_REDIRECTS})")
+    raise UrlFetchError(f"Too many redirects (>{limit})")
 
 
 def _read_from_path(file_path: str) -> tuple[bytes, str]:

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -31,7 +31,9 @@ from openextract._extract import (
     _get_media_type,
     _is_public_ip,
     _is_safe_host,
+    _max_redirects,
     _run_with_shared_agent,
+    _url_fetch_timeout,
 )
 
 
@@ -342,6 +344,49 @@ class TestFetchUrl:
 
         with pytest.raises(UrlFetchError, match="Too many redirects"):
             _fetch_url("https://1.1.1.1/loop")
+
+
+class TestUrlFetchConfiguration:
+    def test_default_timeout_and_redirects(self, monkeypatch):
+        monkeypatch.delenv("OPENEXTRACT_URL_TIMEOUT", raising=False)
+        monkeypatch.delenv("OPENEXTRACT_MAX_REDIRECTS", raising=False)
+        assert _url_fetch_timeout() == 30.0
+        assert _max_redirects() == 10
+
+    def test_custom_timeout_from_env(self, monkeypatch, mocker):
+        monkeypatch.setenv("OPENEXTRACT_URL_TIMEOUT", "45")
+        fake_response = _build_response(content=b"ok")
+        mock_get = mocker.patch("openextract._extract.httpx.get", return_value=fake_response)
+
+        _fetch_url("https://1.1.1.1/doc.pdf")
+
+        assert mock_get.call_args.kwargs["timeout"] == 45.0
+
+    def test_invalid_timeout_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("OPENEXTRACT_URL_TIMEOUT", "not-a-number")
+        assert _url_fetch_timeout() == 30.0
+
+    def test_non_positive_timeout_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("OPENEXTRACT_URL_TIMEOUT", "0")
+        assert _url_fetch_timeout() == 30.0
+
+    def test_custom_max_redirects_from_env(self, monkeypatch, mocker):
+        monkeypatch.setenv("OPENEXTRACT_MAX_REDIRECTS", "2")
+        redirect = _build_response(
+            content=b"", status_code=302, is_redirect=True, location="https://1.1.1.1/loop"
+        )
+        mocker.patch("openextract._extract.httpx.get", return_value=redirect)
+
+        with pytest.raises(UrlFetchError, match="Too many redirects \\(>2\\)"):
+            _fetch_url("https://1.1.1.1/loop")
+
+    def test_invalid_max_redirects_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("OPENEXTRACT_MAX_REDIRECTS", "-1")
+        assert _max_redirects() == 10
+
+    def test_invalid_redirect_count_string_falls_back(self, monkeypatch):
+        monkeypatch.setenv("OPENEXTRACT_MAX_REDIRECTS", "not-a-number")
+        assert _max_redirects() == 10
 
 
 class TestSsrfIntegration:


### PR DESCRIPTION
Closes #90

Adds `OPENEXTRACT_URL_TIMEOUT` and `OPENEXTRACT_MAX_REDIRECTS` environment variables.