### PR TITLE
feat: optional provider dependency extras for slimmer installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `max_retries` and `retry_backoff` on `extract_async`, `extract_with_usage`,
   `extract_with_usage_async`, `extract_many`, and `extract_many_async` (per-item
   for batch), matching sync `extract()` retry semantics.
+- Optional dependency extras: `openai`, `anthropic`, `google`, `bedrock`,
+  `cohere`, `groq`, `huggingface`, `mistral`, `openrouter`, `xai`, `logfire`,
+  and `all`.
 
 ### Changed
+- **Breaking:** Core dependencies no longer install every `pydantic-ai-slim`
+  provider extra by default. Install the providers you need, e.g.
+  `pip install openextract[openai]` or `openextract[all]`.
 - Expand README API reference to document `extract_async`, `extract_many`,
   `extract_with_usage`, and related public APIs.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Thanks for your interest in contributing to openextract!
    cd openextract
    ```
 
-2. Install dependencies with uv:
+2. Install dependencies with uv (includes all provider extras for tests):
    ```bash
    uv sync --dev
    ```

--- a/README.md
+++ b/README.md
@@ -32,14 +32,16 @@
 ## Installation
 
 ```bash
-uv add openextract
+uv add openextract[openai]
 ```
 
 Or with pip:
 
 ```bash
-pip install openextract
+pip install openextract[openai]
 ```
+
+Install additional providers via optional extras, e.g. `openextract[anthropic]`, `openextract[google]`, or every provider with `openextract[all]`. The base package includes `pydantic-ai-slim` without provider SDKs; you need at least one provider extra for model calls.
 
 Requires Python 3.12+.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,24 @@ classifiers = [
 ]
 dependencies = [
     "pydantic>=2.12.5",
-    "pydantic-ai-slim[anthropic,bedrock,cohere,google,groq,huggingface,logfire,mistral,openai,openrouter,xai]>=1.37.0",
+    "pydantic-ai-slim>=1.37.0",
     "python-dotenv>=1.2.2",
+]
+
+[project.optional-dependencies]
+openai = ["pydantic-ai-slim[openai]>=1.37.0"]
+anthropic = ["pydantic-ai-slim[anthropic]>=1.37.0"]
+google = ["pydantic-ai-slim[google]>=1.37.0"]
+bedrock = ["pydantic-ai-slim[bedrock]>=1.37.0"]
+cohere = ["pydantic-ai-slim[cohere]>=1.37.0"]
+groq = ["pydantic-ai-slim[groq]>=1.37.0"]
+huggingface = ["pydantic-ai-slim[huggingface]>=1.37.0"]
+mistral = ["pydantic-ai-slim[mistral]>=1.37.0"]
+openrouter = ["pydantic-ai-slim[openrouter]>=1.37.0"]
+xai = ["pydantic-ai-slim[xai]>=1.37.0"]
+logfire = ["pydantic-ai-slim[logfire]>=1.37.0"]
+all = [
+    "pydantic-ai-slim[anthropic,bedrock,cohere,google,groq,huggingface,logfire,mistral,openai,openrouter,xai]>=1.37.0",
 ]
 
 [project.scripts]
@@ -49,6 +65,7 @@ dev = [
     "pytest-mock>=3.15.1",
     "ruff>=0.14.10",
     "ty>=0.0.35",
+    "pydantic-ai-slim[anthropic,bedrock,cohere,google,groq,huggingface,logfire,mistral,openai,openrouter,xai]>=1.37.0",
 ]
 
 [tool.ty]

--- a/uv.lock
+++ b/uv.lock
@@ -1233,12 +1233,51 @@ version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
-    { name = "pydantic-ai-slim", extra = ["anthropic", "bedrock", "cohere", "google", "groq", "huggingface", "logfire", "mistral", "openai", "openrouter", "xai"] },
+    { name = "pydantic-ai-slim" },
     { name = "python-dotenv" },
+]
+
+[package.optional-dependencies]
+all = [
+    { name = "pydantic-ai-slim", extra = ["anthropic", "bedrock", "cohere", "google", "groq", "huggingface", "logfire", "mistral", "openai", "openrouter", "xai"] },
+]
+anthropic = [
+    { name = "pydantic-ai-slim", extra = ["anthropic"] },
+]
+bedrock = [
+    { name = "pydantic-ai-slim", extra = ["bedrock"] },
+]
+cohere = [
+    { name = "pydantic-ai-slim", extra = ["cohere"] },
+]
+google = [
+    { name = "pydantic-ai-slim", extra = ["google"] },
+]
+groq = [
+    { name = "pydantic-ai-slim", extra = ["groq"] },
+]
+huggingface = [
+    { name = "pydantic-ai-slim", extra = ["huggingface"] },
+]
+logfire = [
+    { name = "pydantic-ai-slim", extra = ["logfire"] },
+]
+mistral = [
+    { name = "pydantic-ai-slim", extra = ["mistral"] },
+]
+openai = [
+    { name = "pydantic-ai-slim", extra = ["openai"] },
+]
+openrouter = [
+    { name = "pydantic-ai-slim", extra = ["openrouter"] },
+]
+xai = [
+    { name = "pydantic-ai-slim", extra = ["xai"] },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "pydantic-ai-slim", extra = ["anthropic", "bedrock", "cohere", "google", "groq", "huggingface", "logfire", "mistral", "openai", "openrouter", "xai"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1250,12 +1289,26 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5" },
-    { name = "pydantic-ai-slim", extras = ["anthropic", "bedrock", "cohere", "google", "groq", "huggingface", "logfire", "mistral", "openai", "openrouter", "xai"], specifier = ">=1.37.0" },
+    { name = "pydantic-ai-slim", specifier = ">=1.37.0" },
+    { name = "pydantic-ai-slim", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.37.0" },
+    { name = "pydantic-ai-slim", extras = ["anthropic", "bedrock", "cohere", "google", "groq", "huggingface", "logfire", "mistral", "openai", "openrouter", "xai"], marker = "extra == 'all'", specifier = ">=1.37.0" },
+    { name = "pydantic-ai-slim", extras = ["bedrock"], marker = "extra == 'bedrock'", specifier = ">=1.37.0" },
+    { name = "pydantic-ai-slim", extras = ["cohere"], marker = "extra == 'cohere'", specifier = ">=1.37.0" },
+    { name = "pydantic-ai-slim", extras = ["google"], marker = "extra == 'google'", specifier = ">=1.37.0" },
+    { name = "pydantic-ai-slim", extras = ["groq"], marker = "extra == 'groq'", specifier = ">=1.37.0" },
+    { name = "pydantic-ai-slim", extras = ["huggingface"], marker = "extra == 'huggingface'", specifier = ">=1.37.0" },
+    { name = "pydantic-ai-slim", extras = ["logfire"], marker = "extra == 'logfire'", specifier = ">=1.37.0" },
+    { name = "pydantic-ai-slim", extras = ["mistral"], marker = "extra == 'mistral'", specifier = ">=1.37.0" },
+    { name = "pydantic-ai-slim", extras = ["openai"], marker = "extra == 'openai'", specifier = ">=1.37.0" },
+    { name = "pydantic-ai-slim", extras = ["openrouter"], marker = "extra == 'openrouter'", specifier = ">=1.37.0" },
+    { name = "pydantic-ai-slim", extras = ["xai"], marker = "extra == 'xai'", specifier = ">=1.37.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
 ]
+provides-extras = ["openai", "anthropic", "google", "bedrock", "cohere", "groq", "huggingface", "mistral", "openrouter", "xai", "logfire", "all"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pydantic-ai-slim", extras = ["anthropic", "bedrock", "cohere", "google", "groq", "huggingface", "logfire", "mistral", "openai", "openrouter", "xai"], specifier = ">=1.37.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },


### PR DESCRIPTION
Closes #92

**Breaking:** install provider extras explicitly, e.g. `pip install openextract[openai]` or `openextract[all]`.