### PR TITLE
feat: add examples for batch extraction and token usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Optional dependency extras: `openai`, `anthropic`, `google`, `bedrock`,
   `cohere`, `groq`, `huggingface`, `mistral`, `openrouter`, `xai`, `logfire`,
   and `all`.
+- Examples `batch_invoices.py` and `extract_with_usage.py` for concurrent batch
+  extraction and token usage reporting.
 
 ### Changed
 - **Breaking:** Core dependencies no longer install every `pydantic-ai-slim`

--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ Runnable scripts live in the [`examples/`](examples/) directory. Each one takes 
 | `invoice_extraction.py`   | PDF invoice -> structured line items                    |
 | `receipt_extraction.py`   | receipt image -> merchant, items, totals                |
 | `meeting_notes.py`        | audio -> summary, decisions, action items               |
+| `batch_invoices.py`       | many PDFs -> concurrent `extract_many` over a directory |
+| `extract_with_usage.py`   | single file -> result plus token usage counts           |
 
 Run any example with `uv` once your provider credentials (e.g. `OPENAI_API_KEY`) are set:
 

--- a/examples/batch_invoices.py
+++ b/examples/batch_invoices.py
@@ -1,0 +1,65 @@
+"""Extract structured invoice data from many PDFs concurrently."""
+
+import sys
+from datetime import date
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from openextract import extract_many
+
+
+class LineItem(BaseModel):
+    description: str
+    quantity: float
+    unit_price: float
+    total: float
+
+
+class Invoice(BaseModel):
+    invoice_number: str
+    issue_date: date
+    seller: str
+    buyer: str
+    line_items: list[LineItem]
+    subtotal: float
+    tax: float
+    total: float
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: uv run python examples/batch_invoices.py <dir-or-pdf> [...]")
+        sys.exit(1)
+
+    paths: list[str] = []
+    for arg in sys.argv[1:]:
+        p = Path(arg)
+        if p.is_dir():
+            paths.extend(str(f) for f in sorted(p.glob("*.pdf")))
+        else:
+            paths.append(str(p))
+
+    if not paths:
+        print("No PDF files found.")
+        sys.exit(1)
+
+    results = extract_many(
+        schema=Invoice,
+        model="openai:gpt-5",
+        input_files=paths,
+        max_concurrency=5,
+        instructions=(
+            "Extract invoice metadata, parties, line items, and totals. "
+            "Use ISO 8601 for issue_date."
+        ),
+    )
+
+    for path, invoice in zip(paths, results, strict=True):
+        print(f"=== {path} ===")
+        print(invoice.model_dump_json(indent=2))
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/extract_with_usage.py
+++ b/examples/extract_with_usage.py
@@ -1,0 +1,37 @@
+"""Extract structured data and print token usage for cost tracking."""
+
+import sys
+
+from pydantic import BaseModel
+
+from openextract import extract_with_usage
+
+
+class PdfInfo(BaseModel):
+    summary: str
+    language: str
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: uv run python examples/extract_with_usage.py <file-or-url>")
+        sys.exit(1)
+
+    input_file = sys.argv[1]
+
+    result, usage = extract_with_usage(
+        schema=PdfInfo,
+        model="openai:gpt-5",
+        input_file=input_file,
+        instructions="Return a two-sentence summary and the document's primary language.",
+    )
+
+    print(result.model_dump_json(indent=2))
+    print(
+        f"\ntokens: {usage.input_tokens} in / {usage.output_tokens} out / "
+        f"{usage.total_tokens} total"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #91

Adds `examples/batch_invoices.py` and `examples/extract_with_usage.py`.