### PR TITLE
feat: CLI batch mode, --usage, --media-type, and stdin support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   and `all`.
 - Examples `batch_invoices.py` and `extract_with_usage.py` for concurrent batch
   extraction and token usage reporting.
+- CLI accepts multiple `input_file` arguments for batch extraction via `extract_many`.
+- `--usage`, `--media-type`, and stdin (`-`) support on the `openextract` command.
 
 ### Changed
 - **Breaking:** Core dependencies no longer install every `pydantic-ai-slim`

--- a/README.md
+++ b/README.md
@@ -163,11 +163,40 @@ openextract ./reports/q4.pdf \
   --output json
 ```
 
-- `<input_file>` is a positional argument; a local path or `https://` URL.
+Batch multiple files (JSON array output):
+
+```bash
+openextract ./invoices/a.pdf ./invoices/b.pdf \
+  --schema mypkg.schemas:Invoice \
+  --model openai:gpt-5
+```
+
+Token usage (single file):
+
+```bash
+openextract ./reports/q4.pdf \
+  --schema mypkg.schemas:Invoice \
+  --model openai:gpt-5 \
+  --usage
+```
+
+Read from stdin:
+
+```bash
+cat ./reports/q4.pdf | openextract - \
+  --schema mypkg.schemas:Invoice \
+  --model openai:gpt-5 \
+  --media-type application/pdf
+```
+
+- `input_file` accepts one or more paths/URLs, or `-` for stdin (`--media-type` required for stdin).
 - `--schema` is a Python import path of the form `module:ClassName` resolving to a Pydantic model.
 - `--model` is a `pydantic-ai` model identifier.
 - `--instructions` is optional natural-language guidance.
-- `--output` is `json` (default; prints `model_dump_json(indent=2)`) or `repr`.
+- `--media-type` sets MIME type for stdin or overrides guessing for paths/URLs.
+- `--usage` prints a JSON object with `result` and `usage` (single input only).
+- `--output` is `json` (default) or `repr`.
+- `--max-retries` / `--retry-backoff` match the Python API retry behavior.
 
 Exit codes: `0` success, `2` URL fetch error, `3` schema validation error, `4` model error,
 `5` other extraction error, `1` any other failure (including bad `--schema` paths).

--- a/src/openextract/_cli.py
+++ b/src/openextract/_cli.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import argparse
 import importlib
+import json
 import sys
 from collections.abc import Sequence
+from typing import Any, cast
 
 from pydantic import BaseModel
 
-from ._extract import extract
+from ._extract import extract, extract_many, extract_with_usage
 from .exceptions import ExtractionError, ModelError, SchemaValidationError, UrlFetchError
 
 
@@ -38,14 +40,47 @@ def _resolve_schema(schema_path: str) -> type[BaseModel]:
     return cls
 
 
+def _resolve_input_files(
+    raw_inputs: list[str],
+    *,
+    media_type: str | None,
+) -> list[str | bytes]:
+    """Resolve CLI paths, URLs, or stdin ``-`` to values accepted by ``extract``."""
+    if "-" in raw_inputs:
+        if len(raw_inputs) > 1:
+            raise ValueError("stdin (-) cannot be combined with other input files")
+        if not media_type:
+            raise ValueError("--media-type is required when reading from stdin (-)")
+        return [sys.stdin.buffer.read()]
+
+    return cast(list[str | bytes], raw_inputs)
+
+
+def _usage_payload(usage) -> dict[str, int]:
+    return {
+        "input_tokens": usage.input_tokens,
+        "output_tokens": usage.output_tokens,
+        "total_tokens": usage.total_tokens,
+    }
+
+
+def _print_json(payload: Any, *, as_repr: bool) -> None:
+    if as_repr:
+        print(repr(payload))
+        return
+    print(json.dumps(payload, indent=2, default=str))
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="openextract",
-        description="Extract structured data from a file or URL using an LLM.",
+        description="Extract structured data from files or URLs using an LLM.",
     )
     parser.add_argument(
-        "input_file",
-        help="Path or URL of the document, image, audio, or video to extract from.",
+        "input_files",
+        nargs="+",
+        metavar="input_file",
+        help="One or more paths/URLs, or '-' to read bytes from stdin.",
     )
     parser.add_argument(
         "--schema",
@@ -63,10 +98,21 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Optional natural-language instructions for the model.",
     )
     parser.add_argument(
+        "--media-type",
+        default=None,
+        metavar="MIME",
+        help="MIME type (required for stdin; optional override for paths/URLs).",
+    )
+    parser.add_argument(
+        "--usage",
+        action="store_true",
+        help="Print token usage (single input only).",
+    )
+    parser.add_argument(
         "--output",
         choices=("json", "repr"),
         default="json",
-        help="Output format: 'json' (default) prints model_dump_json; 'repr' prints repr().",
+        help="Output format: 'json' (default) or 'repr'.",
     )
     parser.add_argument(
         "--max-retries",
@@ -97,14 +143,52 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 1
 
     try:
-        result = extract(
-            schema=schema_cls,
-            model=args.model,
-            input_file=args.input_file,
-            instructions=args.instructions,
-            max_retries=args.max_retries,
-            retry_backoff=args.retry_backoff,
-        )
+        input_files = _resolve_input_files(args.input_files, media_type=args.media_type)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.usage and len(input_files) != 1:
+        print("error: --usage requires exactly one input file", file=sys.stderr)
+        return 1
+
+    media_type = args.media_type
+
+    try:
+        if len(input_files) == 1:
+            input_file = input_files[0]
+            if args.usage:
+                result, usage = extract_with_usage(
+                    schema=schema_cls,
+                    model=args.model,
+                    input_file=input_file,
+                    instructions=args.instructions,
+                    media_type=media_type,
+                    max_retries=args.max_retries,
+                    retry_backoff=args.retry_backoff,
+                )
+                payload: Any = {"result": result.model_dump(), "usage": _usage_payload(usage)}
+            else:
+                payload = extract(
+                    schema=schema_cls,
+                    model=args.model,
+                    input_file=input_file,
+                    instructions=args.instructions,
+                    media_type=media_type,
+                    max_retries=args.max_retries,
+                    retry_backoff=args.retry_backoff,
+                )
+        else:
+            results = extract_many(
+                schema=schema_cls,
+                model=args.model,
+                input_files=input_files,
+                instructions=args.instructions,
+                media_type=media_type,
+                max_retries=args.max_retries,
+                retry_backoff=args.retry_backoff,
+            )
+            payload = [r.model_dump() for r in results]
     except UrlFetchError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
@@ -118,10 +202,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"error: {exc}", file=sys.stderr)
         return 5
 
-    if args.output == "json":
-        print(result.model_dump_json(indent=2))
+    if args.output == "repr":
+        _print_json(payload, as_repr=True)
+    elif len(input_files) == 1 and not args.usage and isinstance(payload, BaseModel):
+        print(payload.model_dump_json(indent=2))
     else:
-        print(repr(result))
+        _print_json(payload, as_repr=False)
     return 0
 
 

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -464,6 +464,7 @@ def extract_with_usage(
     Same retry semantics as :func:`extract`. Returns a :class:`Usage` describing
     the tokens consumed by the successful model call.
     """
+
     def _once() -> tuple[T, Usage]:
         result = _run_extraction(schema, model, input_file, instructions, media_type)
         return cast(T, result.output), _usage_from_result(result)
@@ -482,6 +483,7 @@ async def extract_with_usage_async(
     retry_backoff: float = 1.0,
 ) -> tuple[T, Usage]:
     """Async sibling of :func:`extract_with_usage`; returns ``(output, Usage)``."""
+
     async def _once() -> tuple[T, Usage]:
         with _extraction_errors():
             agent, inputs = _prepare_run(schema, model, input_file, instructions, media_type)
@@ -506,6 +508,7 @@ async def extract_async(
     retry_backoff: float = 1.0,
 ) -> T:
     """Async sibling of :func:`extract`; uses ``Agent.run`` instead of ``run_sync``."""
+
     async def _once() -> T:
         with _extraction_errors():
             agent, inputs = _prepare_run(schema, model, input_file, instructions, media_type)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,6 +32,24 @@ def _patch_extract(mocker, return_value=None, side_effect=None):
     return mock_extract
 
 
+def _patch_extract_with_usage(mocker, return_value=None, side_effect=None):
+    mock_fn = mocker.patch("openextract._cli.extract_with_usage")
+    if side_effect is not None:
+        mock_fn.side_effect = side_effect
+    else:
+        mock_fn.return_value = return_value
+    return mock_fn
+
+
+def _patch_extract_many(mocker, return_value=None, side_effect=None):
+    mock_fn = mocker.patch("openextract._cli.extract_many")
+    if side_effect is not None:
+        mock_fn.side_effect = side_effect
+    else:
+        mock_fn.return_value = return_value
+    return mock_fn
+
+
 # ---------------------------------------------------------------------------
 # _resolve_schema
 # ---------------------------------------------------------------------------
@@ -119,8 +137,7 @@ class TestArgparse:
 
 class TestMainSuccess:
     def test_json_output_default(self, mocker, capsys):
-        fake = MagicMock()
-        fake.model_dump_json.return_value = '{\n  "name": "Ada",\n  "age": 36\n}'
+        fake = _FixtureSchema(name="Ada", age=36)
         mock_extract = _patch_extract(mocker, return_value=fake)
 
         exit_code = main(
@@ -136,17 +153,17 @@ class TestMainSuccess:
         )
 
         assert exit_code == 0
-        fake.model_dump_json.assert_called_once_with(indent=2)
+        captured = capsys.readouterr()
+        assert '"name": "Ada"' in captured.out
         mock_extract.assert_called_once_with(
             schema=_FixtureSchema,
             model="openai:gpt-5",
             input_file="input.txt",
             instructions="find the person",
+            media_type=None,
             max_retries=0,
             retry_backoff=1.0,
         )
-        captured = capsys.readouterr()
-        assert '"name": "Ada"' in captured.out
 
     def test_repr_output(self, mocker, capsys):
         fake = MagicMock()
@@ -287,3 +304,124 @@ class TestMainErrorCodes:
         )
         assert exit_code == 1
         assert "BaseModel" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# batch, usage, stdin
+# ---------------------------------------------------------------------------
+
+
+class TestMainBatchAndUsage:
+    def test_multiple_files_use_extract_many(self, mocker, capsys):
+        fake = MagicMock()
+        fake.model_dump.return_value = {"name": "Ada", "age": 36}
+        mock_many = _patch_extract_many(mocker, return_value=[fake, fake])
+
+        exit_code = main(
+            [
+                "a.pdf",
+                "b.pdf",
+                "--schema",
+                "tests.test_cli:_FixtureSchema",
+                "--model",
+                "openai:gpt-5",
+            ]
+        )
+
+        assert exit_code == 0
+        mock_many.assert_called_once()
+        captured = capsys.readouterr()
+        assert '"name": "Ada"' in captured.out
+
+    def test_usage_flag_calls_extract_with_usage(self, mocker, capsys):
+        from openextract import Usage
+
+        fake = MagicMock()
+        fake.model_dump.return_value = {"name": "Ada", "age": 36}
+        usage = Usage(input_tokens=10, output_tokens=5, total_tokens=15)
+        mock_usage = _patch_extract_with_usage(mocker, return_value=(fake, usage))
+
+        exit_code = main(
+            [
+                "input.txt",
+                "--schema",
+                "tests.test_cli:_FixtureSchema",
+                "--model",
+                "openai:gpt-5",
+                "--usage",
+            ]
+        )
+
+        assert exit_code == 0
+        mock_usage.assert_called_once()
+        captured = capsys.readouterr()
+        assert '"usage"' in captured.out
+        assert captured.out.count("input_tokens") >= 1
+
+    def test_usage_with_multiple_inputs_returns_1(self, capsys):
+        exit_code = main(
+            [
+                "a.pdf",
+                "b.pdf",
+                "--schema",
+                "tests.test_cli:_FixtureSchema",
+                "--model",
+                "openai:gpt-5",
+                "--usage",
+            ]
+        )
+        assert exit_code == 1
+        assert "exactly one" in capsys.readouterr().err
+
+    def test_stdin_without_media_type_returns_1(self, capsys, mocker):
+        mocker.patch("sys.stdin")
+        exit_code = main(
+            [
+                "-",
+                "--schema",
+                "tests.test_cli:_FixtureSchema",
+                "--model",
+                "openai:gpt-5",
+            ]
+        )
+        assert exit_code == 1
+        assert "media-type" in capsys.readouterr().err.lower()
+
+    def test_stdin_with_other_paths_returns_1(self, capsys):
+        exit_code = main(
+            [
+                "-",
+                "other.pdf",
+                "--schema",
+                "tests.test_cli:_FixtureSchema",
+                "--model",
+                "openai:gpt-5",
+                "--media-type",
+                "application/pdf",
+            ]
+        )
+        assert exit_code == 1
+        assert "stdin" in capsys.readouterr().err.lower()
+
+    def test_stdin_reads_buffer(self, mocker, capsys):
+        fake = MagicMock()
+        fake.model_dump_json.return_value = "{}"
+        mock_extract = _patch_extract(mocker, return_value=fake)
+        stdin = mocker.patch("openextract._cli.sys.stdin")
+        stdin.buffer.read.return_value = b"%PDF-bytes"
+
+        exit_code = main(
+            [
+                "-",
+                "--schema",
+                "tests.test_cli:_FixtureSchema",
+                "--model",
+                "openai:gpt-5",
+                "--media-type",
+                "application/pdf",
+            ]
+        )
+
+        assert exit_code == 0
+        assert mock_extract.call_args.kwargs["input_file"] == b"%PDF-bytes"
+        assert mock_extract.call_args.kwargs["media_type"] == "application/pdf"


### PR DESCRIPTION
Closes #95

CLI supports multiple inputs, token usage output, MIME type flag, and stdin (`-`).