### PR TITLE
release: 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `--usage`, `--media-type`, and stdin (`-`) support on the `openextract` command.
 
 ### Changed
-- **Breaking:** Core dependencies no longer install every `pydantic-ai-slim`
-  provider extra by default. Install the providers you need, e.g.
-  `pip install openextract[openai]` or `openextract[all]`.
+- **Breaking:** `pip install openextract` no longer bundles every provider SDK.
+  Install a provider extra for model calls (e.g. `openextract[openai]` or `openextract[all]`).
 - Expand README API reference to document `extract_async`, `extract_many`,
   `extract_with_usage`, and related public APIs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-02
+
 ### Added
 - Environment variables `OPENEXTRACT_URL_TIMEOUT` and `OPENEXTRACT_MAX_REDIRECTS`
   to configure HTTP timeout and redirect limits when fetching URLs.
@@ -101,7 +103,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.1.1] - 2025-09-10
 - Merge pull request #12 from Mellow-Artificial-Intelligence/new-release.
 
-[Unreleased]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.4.0...v0.5.0

--- a/README.md
+++ b/README.md
@@ -32,16 +32,16 @@
 ## Installation
 
 ```bash
-uv add openextract[openai]
+uv add openextract
 ```
 
 Or with pip:
 
 ```bash
-pip install openextract[openai]
+pip install openextract
 ```
 
-Install additional providers via optional extras, e.g. `openextract[anthropic]`, `openextract[google]`, or every provider with `openextract[all]`. The base package includes `pydantic-ai-slim` without provider SDKs; you need at least one provider extra for model calls.
+Model calls require a provider SDK. Install the extra for the provider you use, for example `openextract[openai]`, `openextract[anthropic]`, or `openextract[all]` for every supported provider. The base package ships `pydantic-ai-slim` without provider SDKs pre-installed.
 
 Requires Python 3.12+.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,9 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.6.x   | :white_check_mark: |
-| < 0.6   | :x:                |
+| 0.8.x   | :white_check_mark: |
+| 0.7.x   | :white_check_mark: |
+| < 0.7   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -123,7 +123,7 @@
                View Source
             </a>
             <button onclick="copyInstall()" class="h-10 px-3 sm:px-4 bg-white border border-black/10 text-black/70 font-mono text-xs sm:text-sm flex items-center justify-center gap-2 sm:gap-3 hover:bg-black/5 hover:border-black/20 transition-all group">
-              <span class="text-black/30">$</span> <span class="truncate">uv add openextract[openai]</span>
+              <span class="text-black/30">$</span> <span class="truncate">uv add openextract</span>
               <span id="copy-icon" class="text-black/30 group-hover:text-black/50 flex-shrink-0"><i data-lucide="copy" class="w-3.5 h-3.5"></i></span>
               <span id="check-icon" class="hidden text-emerald-500 flex-shrink-0"><i data-lucide="check" class="w-3.5 h-3.5"></i></span>
             </button>
@@ -487,7 +487,7 @@
       }
 
       function copyInstall() {
-        copyToClipboard("uv add openextract[openai]").then(() => {
+        copyToClipboard("uv add openextract").then(() => {
           document.getElementById('copy-icon').classList.add('hidden');
           document.getElementById('check-icon').classList.remove('hidden');
           setTimeout(() => {
@@ -498,7 +498,7 @@
       }
 
       function copyInstallBasic() {
-        copyToClipboard("uv add openextract[openai]").then(() => {
+        copyToClipboard("uv add openextract").then(() => {
           document.getElementById('copy-icon-basic').classList.add('hidden');
           document.getElementById('check-icon-basic').classList.remove('hidden');
           setTimeout(() => {

--- a/docs/index.html
+++ b/docs/index.html
@@ -123,7 +123,7 @@
                View Source
             </a>
             <button onclick="copyInstall()" class="h-10 px-3 sm:px-4 bg-white border border-black/10 text-black/70 font-mono text-xs sm:text-sm flex items-center justify-center gap-2 sm:gap-3 hover:bg-black/5 hover:border-black/20 transition-all group">
-              <span class="text-black/30">$</span> <span class="truncate">uv add openextract</span>
+              <span class="text-black/30">$</span> <span class="truncate">uv add openextract[openai]</span>
               <span id="copy-icon" class="text-black/30 group-hover:text-black/50 flex-shrink-0"><i data-lucide="copy" class="w-3.5 h-3.5"></i></span>
               <span id="check-icon" class="hidden text-emerald-500 flex-shrink-0"><i data-lucide="check" class="w-3.5 h-3.5"></i></span>
             </button>
@@ -487,7 +487,7 @@
       }
 
       function copyInstall() {
-        copyToClipboard("uv add openextract").then(() => {
+        copyToClipboard("uv add openextract[openai]").then(() => {
           document.getElementById('copy-icon').classList.add('hidden');
           document.getElementById('check-icon').classList.remove('hidden');
           setTimeout(() => {
@@ -498,7 +498,7 @@
       }
 
       function copyInstallBasic() {
-        copyToClipboard("uv add openextract").then(() => {
+        copyToClipboard("uv add openextract[openai]").then(() => {
           document.getElementById('copy-icon-basic').classList.add('hidden');
           document.getElementById('check-icon-basic').classList.remove('hidden');
           setTimeout(() => {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openextract"
-version = "0.7.0"
+version = "0.8.0"
 description = "Extract structured data from documents, images, audio, and video using LLMs"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1229,7 +1229,7 @@ wheels = [
 
 [[package]]
 name = "openextract"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Minor release **0.8.0** packages everything merged to `main` since v0.7.0 (PRs #97–#103).

## Version bump

`0.7.0` → **`0.8.0`** (minor): new features and a **breaking** install change (provider extras are optional; use `openextract[openai]` or `openextract[all]`).

## Changes in this PR

- `pyproject.toml` / `uv.lock`: version `0.8.0`
- `CHANGELOG.md`: release notes under `[0.8.0] - 2026-06-02`, empty `[Unreleased]`
- `SECURITY.md`: support matrix for 0.8.x and 0.7.x
- `docs/index.html`: install CTA uses `uv add openextract[openai]` (matches README)

## After merge

The [release workflow](.github/workflows/release.yml) runs on push to `main`. When this lands, it will:

1. Build the wheel/sdist
2. Publish **0.8.0** to PyPI (if not already published)
3. Create GitHub release **v0.8.0**

## Upgrade note for consumers

```bash
pip install 'openextract[openai]>=0.8.0'
# or
uv add 'openextract[openai]>=0.8.0'
```

Plain `pip install openextract` no longer pulls all provider SDKs by default.

## Testing

- `uv run pytest` (100% coverage)
- `uv run ruff check .` / `ruff format --check .`
- `uv run ty check`