### PR TITLE
docs: use xAI in examples and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ class PdfInfo(BaseModel):
 
 result = extract(
     schema=PdfInfo,
-    model="openai:gpt-5",
+    model="xai:grok-4",
     input_file="https://example.com/document.pdf",
     instructions="Return a two-sentence summary and the document's primary language.",
 )
@@ -77,7 +77,7 @@ print(result.language)
 ```python
 result = extract(
     schema=PdfInfo,
-    model="openai:gpt-5",
+    model="xai:grok-4",
     input_file="./reports/q4.pdf",
 )
 ```
@@ -85,9 +85,9 @@ result = extract(
 ### Bytes or file-like objects
 
 ```python
-result = extract(schema=PdfInfo, model="openai:gpt-5", input_file=pdf_bytes, media_type="application/pdf")
+result = extract(schema=PdfInfo, model="xai:grok-4", input_file=pdf_bytes, media_type="application/pdf")
 # A file-like object with .read() works too; pass media_type explicitly:
-result = extract(schema=PdfInfo, model="openai:gpt-5", input_file=open("q4.pdf", "rb"), media_type="application/pdf")
+result = extract(schema=PdfInfo, model="xai:grok-4", input_file=open("q4.pdf", "rb"), media_type="application/pdf")
 ```
 
 ### Retry on transient model errors
@@ -95,7 +95,7 @@ result = extract(schema=PdfInfo, model="openai:gpt-5", input_file=open("q4.pdf",
 ```python
 result = extract(
     schema=PdfInfo,
-    model="openai:gpt-5",
+    model="xai:grok-4",
     input_file="./reports/q4.pdf",
     max_retries=3,
 )
@@ -112,7 +112,7 @@ from openextract import extract_with_usage
 
 result, usage = extract_with_usage(
     schema=PdfInfo,
-    model="openai:gpt-5",
+    model="xai:grok-4",
     input_file="./reports/q4.pdf",
 )
 
@@ -145,7 +145,7 @@ print(f"tokens: {usage.input_tokens} in / {usage.output_tokens} out / {usage.tot
 
 Ollama and Cerebras work via the `openai`-compatible code path &mdash; no dedicated extra is required for either.
 
-Set the corresponding provider credentials in your environment (e.g. `OPENAI_API_KEY`). `openextract` loads `.env` automatically.
+Set the corresponding provider credentials in your environment (e.g. `XAI_API_KEY` for xAI). `openextract` loads `.env` automatically.
 
 OpenRouter and Cerebras are openai-compatible (they go through the `openai` client under the hood), so their errors are already classified via the existing openai path &mdash; no separate exception handling is needed.
 
@@ -158,7 +158,7 @@ Outlines runs models locally (via HuggingFace transformers, llama-cpp, MLX, vLLM
 ```bash
 openextract ./reports/q4.pdf \
   --schema mypkg.schemas:Invoice \
-  --model openai:gpt-5 \
+  --model xai:grok-4 \
   --instructions "Pull totals and line items." \
   --output json
 ```
@@ -168,7 +168,7 @@ Batch multiple files (JSON array output):
 ```bash
 openextract ./invoices/a.pdf ./invoices/b.pdf \
   --schema mypkg.schemas:Invoice \
-  --model openai:gpt-5
+  --model xai:grok-4
 ```
 
 Token usage (single file):
@@ -176,7 +176,7 @@ Token usage (single file):
 ```bash
 openextract ./reports/q4.pdf \
   --schema mypkg.schemas:Invoice \
-  --model openai:gpt-5 \
+  --model xai:grok-4 \
   --usage
 ```
 
@@ -185,7 +185,7 @@ Read from stdin:
 ```bash
 cat ./reports/q4.pdf | openextract - \
   --schema mypkg.schemas:Invoice \
-  --model openai:gpt-5 \
+  --model xai:grok-4 \
   --media-type application/pdf
 ```
 
@@ -213,7 +213,7 @@ Runnable scripts live in the [`examples/`](examples/) directory. Each one takes 
 | `batch_invoices.py`       | many PDFs -> concurrent `extract_many` over a directory |
 | `extract_with_usage.py`   | single file -> result plus token usage counts           |
 
-Run any example with `uv` once your provider credentials (e.g. `OPENAI_API_KEY`) are set:
+Run any example with `uv` once your provider credentials (e.g. `XAI_API_KEY`) are set:
 
 ```bash
 uv run python examples/invoice_extraction.py ./invoices/q4.pdf
@@ -233,7 +233,7 @@ from openextract import (
 )
 
 try:
-    result = extract(schema=PdfInfo, model="openai:gpt-5", input_file=url)
+    result = extract(schema=PdfInfo, model="xai:grok-4", input_file=url)
 except UrlFetchError:
     ...  # The URL could not be fetched
 except SchemaValidationError:
@@ -253,7 +253,7 @@ All `openextract` exceptions inherit from `ExtractionError`, so you can catch it
 | Argument        | Type                          | Description                                                                                                       |
 | --------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `schema`        | `type[BaseModel]`             | A Pydantic model class describing the desired output shape.                                                       |
-| `model`         | `str`                         | A `pydantic-ai` model identifier (e.g. `"openai:gpt-5"`).                                                         |
+| `model`         | `str`                         | A `pydantic-ai` model identifier (e.g. `"xai:grok-4"`).                                                         |
 | `input_file`    | `str \| bytes \| BinaryIO`    | A local file path, an `https://` URL, raw `bytes`, or a binary file-like object with a `.read()` method.          |
 | `instructions`  | `str \| None`                 | Optional natural-language guidance for the model.                                                                 |
 | `media_type`    | `str \| None` (keyword-only)  | MIME type. Required for `bytes` and file-like inputs; overrides the guessed type for `str` inputs when provided.  |

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@
 
 <span class="text-black/70">result</span> <span class="text-black/40">=</span> <span class="text-black/70">extract</span>(
     <span class="text-black/40">schema=</span><span class="text-black/70">Invoice</span>,
-    <span class="text-black/40">model=</span><span class="text-emerald-600">"openai:gpt-5"</span>,
+    <span class="text-black/40">model=</span><span class="text-emerald-600">"xai:grok-4"</span>,
     <span class="text-black/40">input_file=</span><span class="text-emerald-600">"https://example.com/doc.pdf"</span>,
     <span class="text-black/40">instructions=</span><span class="text-emerald-600">"Extract invoice data"</span>,
 )</code></pre>
@@ -271,7 +271,7 @@
               </p>
               <pre class="text-[11px] font-mono leading-relaxed text-black/60 bg-black/5 p-2.5 overflow-x-auto"><code><span class="text-black/40">$</span> openextract a.pdf b.pdf \
     --schema mypkg:Invoice \
-    --model <span class="text-emerald-600">openai:gpt-5</span> \
+    --model <span class="text-emerald-600">xai:grok-4</span> \
     --usage</code></pre>
             </div>
 
@@ -307,7 +307,7 @@
               </p>
               <pre class="text-[11px] font-mono leading-relaxed text-black/60 bg-black/5 p-2.5 overflow-x-auto"><code>results = extract_many(
     schema=Invoice,
-    model=<span class="text-emerald-600">"openai:gpt-5"</span>,
+    model=<span class="text-emerald-600">"xai:grok-4"</span>,
     input_files=paths,
     max_concurrency=<span class="text-emerald-600">5</span>,
 )</code></pre>
@@ -326,7 +326,7 @@
               </p>
               <pre class="text-[11px] font-mono leading-relaxed text-black/60 bg-black/5 p-2.5 overflow-x-auto"><code>extract(
     schema=Invoice,
-    model=<span class="text-emerald-600">"openai:gpt-5"</span>,
+    model=<span class="text-emerald-600">"xai:grok-4"</span>,
     input_file=pdf_bytes,
     media_type=<span class="text-emerald-600">"application/pdf"</span>,
 )</code></pre>
@@ -345,7 +345,7 @@
               </p>
               <pre class="text-[11px] font-mono leading-relaxed text-black/60 bg-black/5 p-2.5 overflow-x-auto"><code>extract(
     schema=Invoice,
-    model=<span class="text-emerald-600">"openai:gpt-5"</span>,
+    model=<span class="text-emerald-600">"xai:grok-4"</span>,
     input_file=path,
     max_retries=<span class="text-emerald-600">3</span>,
 )</code></pre>
@@ -364,7 +364,7 @@
               </p>
               <pre class="text-[11px] font-mono leading-relaxed text-black/60 bg-black/5 p-2.5 overflow-x-auto"><code>output, usage = extract_with_usage(
     schema=Invoice,
-    model=<span class="text-emerald-600">"openai:gpt-5"</span>,
+    model=<span class="text-emerald-600">"xai:grok-4"</span>,
     input_file=path,
 )
 <span class="text-black/40">print(usage.total_tokens)</span></code></pre>
@@ -461,7 +461,7 @@
 
 <span class="text-black/70">result</span> <span class="text-black/40">=</span> <span class="text-black/70">extract</span>(
     <span class="text-black/40">schema=</span><span class="text-black/70">Report</span>,
-    <span class="text-black/40">model=</span><span class="text-emerald-600">"openai:gpt-5"</span>,
+    <span class="text-black/40">model=</span><span class="text-emerald-600">"xai:grok-4"</span>,
     <span class="text-black/40">input_file=</span><span class="text-emerald-600">"https://example.com/report.pdf"</span>,
     <span class="text-black/40">instructions=</span><span class="text-emerald-600">"Extract findings"</span>,
 )</code></pre>

--- a/examples/batch_invoices.py
+++ b/examples/batch_invoices.py
@@ -46,7 +46,7 @@ def main() -> None:
 
     results = extract_many(
         schema=Invoice,
-        model="openai:gpt-5",
+        model="xai:grok-4",
         input_files=paths,
         max_concurrency=5,
         instructions=(

--- a/examples/extract_with_usage.py
+++ b/examples/extract_with_usage.py
@@ -21,7 +21,7 @@ def main() -> None:
 
     result, usage = extract_with_usage(
         schema=PdfInfo,
-        model="openai:gpt-5",
+        model="xai:grok-4",
         input_file=input_file,
         instructions="Return a two-sentence summary and the document's primary language.",
     )

--- a/examples/invoice_extraction.py
+++ b/examples/invoice_extraction.py
@@ -35,7 +35,7 @@ def main() -> None:
 
     invoice = extract(
         schema=Invoice,
-        model="openai:gpt-5",
+        model="xai:grok-4",
         input_file=input_file,
         instructions=(
             "Extract the invoice metadata, parties, every line item, and the "

--- a/examples/meeting_notes.py
+++ b/examples/meeting_notes.py
@@ -31,7 +31,7 @@ def main() -> None:
 
     meeting = extract(
         schema=Meeting,
-        model="openai:gpt-5",
+        model="xai:grok-4",
         input_file=input_file,
         instructions=(
             "Listen to the meeting audio and produce structured notes. Include "

--- a/examples/receipt_extraction.py
+++ b/examples/receipt_extraction.py
@@ -33,7 +33,7 @@ def main() -> None:
 
     receipt = extract(
         schema=Receipt,
-        model="openai:gpt-5",
+        model="xai:grok-4",
         input_file=input_file,
         instructions=(
             "Read the receipt image and extract the merchant, transaction date, "

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -110,7 +110,7 @@ def bench_build_agent() -> None:
     print("\n[_build_agent] constructing a pydantic_ai.Agent")
     _bench(
         "_build_agent(non-ollama)",
-        lambda: _build_agent(_Person, "openai:gpt-5", "extract"),
+        lambda: _build_agent(_Person, "xai:grok-4", "extract"),
         iters=200,
     )
     _bench(
@@ -137,8 +137,8 @@ def bench_extract_end_to_end(tmp: Path) -> None:
     print("\n[extract] sync extract() with Agent mocked (all-local cost per call)")
     with patch("openextract._extract.Agent", return_value=agent_instance):
         _bench(
-            "extract(path, openai:gpt-5)",
-            lambda: extract(_Person, "openai:gpt-5", str(src)),
+            "extract(path, xai:grok-4)",
+            lambda: extract(_Person, "xai:grok-4", str(src)),
             iters=500,
         )
 
@@ -156,7 +156,7 @@ def bench_extract_end_to_end(tmp: Path) -> None:
     with patch("openextract._extract.Agent", return_value=async_agent_instance):
         _bench(
             "extract_many(20 files, conc=5)",
-            lambda: extract_many(_Person, "openai:gpt-5", files, max_concurrency=5),
+            lambda: extract_many(_Person, "xai:grok-4", files, max_concurrency=5),
             iters=20,
         )
 

--- a/src/openextract/_cli.py
+++ b/src/openextract/_cli.py
@@ -90,7 +90,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--model",
         required=True,
-        help="pydantic-ai model identifier (e.g. 'openai:gpt-5').",
+        help="pydantic-ai model identifier (e.g. 'xai:grok-4').",
     )
     parser.add_argument(
         "--instructions",

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -417,7 +417,7 @@ def extract(
 
     Args:
         schema: A Pydantic model class defining the expected output structure.
-        model: The model identifier (e.g., 'openai:gpt-5').
+        model: The model identifier (e.g., 'xai:grok-4').
         input_file: A local file path, an ``http(s)://`` URL, raw ``bytes``, or
             a binary file-like object with a ``.read()`` method. For ``bytes``
             and file-like inputs, ``media_type`` must be provided.


### PR DESCRIPTION
## Summary

Standardizes example model identifiers on **xAI** (`xai:grok-4`) across user-facing docs and runnable scripts.

## Updated

- `examples/*.py` (all five scripts)
- `README.md` code samples, CLI examples, API reference example, env var hints
- `docs/index.html` code snippets
- CLI help and `extract()` docstring examples
- `scripts/bench.py`

## Unchanged

- Provider reference table (still lists OpenAI, Anthropic, etc.)
- Tests (still use `openai:gpt-5` for mocked provider behavior)
- `CHANGELOG.md` historical entries