### PR TITLE
test: xAI provider errors and grok-4.3 examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ class PdfInfo(BaseModel):
 
 result = extract(
     schema=PdfInfo,
-    model="xai:grok-4",
+    model="xai:grok-4.3",
     input_file="https://example.com/document.pdf",
     instructions="Return a two-sentence summary and the document's primary language.",
 )
@@ -77,7 +77,7 @@ print(result.language)
 ```python
 result = extract(
     schema=PdfInfo,
-    model="xai:grok-4",
+    model="xai:grok-4.3",
     input_file="./reports/q4.pdf",
 )
 ```
@@ -85,9 +85,9 @@ result = extract(
 ### Bytes or file-like objects
 
 ```python
-result = extract(schema=PdfInfo, model="xai:grok-4", input_file=pdf_bytes, media_type="application/pdf")
+result = extract(schema=PdfInfo, model="xai:grok-4.3", input_file=pdf_bytes, media_type="application/pdf")
 # A file-like object with .read() works too; pass media_type explicitly:
-result = extract(schema=PdfInfo, model="xai:grok-4", input_file=open("q4.pdf", "rb"), media_type="application/pdf")
+result = extract(schema=PdfInfo, model="xai:grok-4.3", input_file=open("q4.pdf", "rb"), media_type="application/pdf")
 ```
 
 ### Retry on transient model errors
@@ -95,7 +95,7 @@ result = extract(schema=PdfInfo, model="xai:grok-4", input_file=open("q4.pdf", "
 ```python
 result = extract(
     schema=PdfInfo,
-    model="xai:grok-4",
+    model="xai:grok-4.3",
     input_file="./reports/q4.pdf",
     max_retries=3,
 )
@@ -112,7 +112,7 @@ from openextract import extract_with_usage
 
 result, usage = extract_with_usage(
     schema=PdfInfo,
-    model="xai:grok-4",
+    model="xai:grok-4.3",
     input_file="./reports/q4.pdf",
 )
 
@@ -133,7 +133,7 @@ print(f"tokens: {usage.input_tokens} in / {usage.output_tokens} out / {usage.tot
 | Anthropic    | `anthropic:claude-sonnet-4`                              |
 | Google       | `google-gla:gemini-2.5-pro`                              |
 | AWS Bedrock  | `bedrock:anthropic.claude-sonnet-4-20250514-v1:0`        |
-| xAI          | `xai:grok-4`                                             |
+| xAI          | `xai:grok-4.3`                                             |
 | Cohere       | `cohere:command-r-plus`                                  |
 | Hugging Face | `huggingface:meta-llama/Llama-3.3-70B-Instruct`          |
 | Groq         | `groq:llama-3.3-70b-versatile`                           |
@@ -158,7 +158,7 @@ Outlines runs models locally (via HuggingFace transformers, llama-cpp, MLX, vLLM
 ```bash
 openextract ./reports/q4.pdf \
   --schema mypkg.schemas:Invoice \
-  --model xai:grok-4 \
+  --model xai:grok-4.3 \
   --instructions "Pull totals and line items." \
   --output json
 ```
@@ -168,7 +168,7 @@ Batch multiple files (JSON array output):
 ```bash
 openextract ./invoices/a.pdf ./invoices/b.pdf \
   --schema mypkg.schemas:Invoice \
-  --model xai:grok-4
+  --model xai:grok-4.3
 ```
 
 Token usage (single file):
@@ -176,7 +176,7 @@ Token usage (single file):
 ```bash
 openextract ./reports/q4.pdf \
   --schema mypkg.schemas:Invoice \
-  --model xai:grok-4 \
+  --model xai:grok-4.3 \
   --usage
 ```
 
@@ -185,7 +185,7 @@ Read from stdin:
 ```bash
 cat ./reports/q4.pdf | openextract - \
   --schema mypkg.schemas:Invoice \
-  --model xai:grok-4 \
+  --model xai:grok-4.3 \
   --media-type application/pdf
 ```
 
@@ -233,7 +233,7 @@ from openextract import (
 )
 
 try:
-    result = extract(schema=PdfInfo, model="xai:grok-4", input_file=url)
+    result = extract(schema=PdfInfo, model="xai:grok-4.3", input_file=url)
 except UrlFetchError:
     ...  # The URL could not be fetched
 except SchemaValidationError:
@@ -253,7 +253,7 @@ All `openextract` exceptions inherit from `ExtractionError`, so you can catch it
 | Argument        | Type                          | Description                                                                                                       |
 | --------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `schema`        | `type[BaseModel]`             | A Pydantic model class describing the desired output shape.                                                       |
-| `model`         | `str`                         | A `pydantic-ai` model identifier (e.g. `"xai:grok-4"`).                                                         |
+| `model`         | `str`                         | A `pydantic-ai` model identifier (e.g. `"xai:grok-4.3"`).                                                         |
 | `input_file`    | `str \| bytes \| BinaryIO`    | A local file path, an `https://` URL, raw `bytes`, or a binary file-like object with a `.read()` method.          |
 | `instructions`  | `str \| None`                 | Optional natural-language guidance for the model.                                                                 |
 | `media_type`    | `str \| None` (keyword-only)  | MIME type. Required for `bytes` and file-like inputs; overrides the guessed type for `str` inputs when provided.  |

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@
 
 <span class="text-black/70">result</span> <span class="text-black/40">=</span> <span class="text-black/70">extract</span>(
     <span class="text-black/40">schema=</span><span class="text-black/70">Invoice</span>,
-    <span class="text-black/40">model=</span><span class="text-emerald-600">"xai:grok-4"</span>,
+    <span class="text-black/40">model=</span><span class="text-emerald-600">"xai:grok-4.3"</span>,
     <span class="text-black/40">input_file=</span><span class="text-emerald-600">"https://example.com/doc.pdf"</span>,
     <span class="text-black/40">instructions=</span><span class="text-emerald-600">"Extract invoice data"</span>,
 )</code></pre>
@@ -271,7 +271,7 @@
               </p>
               <pre class="text-[11px] font-mono leading-relaxed text-black/60 bg-black/5 p-2.5 overflow-x-auto"><code><span class="text-black/40">$</span> openextract a.pdf b.pdf \
     --schema mypkg:Invoice \
-    --model <span class="text-emerald-600">xai:grok-4</span> \
+    --model <span class="text-emerald-600">xai:grok-4.3</span> \
     --usage</code></pre>
             </div>
 
@@ -307,7 +307,7 @@
               </p>
               <pre class="text-[11px] font-mono leading-relaxed text-black/60 bg-black/5 p-2.5 overflow-x-auto"><code>results = extract_many(
     schema=Invoice,
-    model=<span class="text-emerald-600">"xai:grok-4"</span>,
+    model=<span class="text-emerald-600">"xai:grok-4.3"</span>,
     input_files=paths,
     max_concurrency=<span class="text-emerald-600">5</span>,
 )</code></pre>
@@ -326,7 +326,7 @@
               </p>
               <pre class="text-[11px] font-mono leading-relaxed text-black/60 bg-black/5 p-2.5 overflow-x-auto"><code>extract(
     schema=Invoice,
-    model=<span class="text-emerald-600">"xai:grok-4"</span>,
+    model=<span class="text-emerald-600">"xai:grok-4.3"</span>,
     input_file=pdf_bytes,
     media_type=<span class="text-emerald-600">"application/pdf"</span>,
 )</code></pre>
@@ -345,7 +345,7 @@
               </p>
               <pre class="text-[11px] font-mono leading-relaxed text-black/60 bg-black/5 p-2.5 overflow-x-auto"><code>extract(
     schema=Invoice,
-    model=<span class="text-emerald-600">"xai:grok-4"</span>,
+    model=<span class="text-emerald-600">"xai:grok-4.3"</span>,
     input_file=path,
     max_retries=<span class="text-emerald-600">3</span>,
 )</code></pre>
@@ -364,7 +364,7 @@
               </p>
               <pre class="text-[11px] font-mono leading-relaxed text-black/60 bg-black/5 p-2.5 overflow-x-auto"><code>output, usage = extract_with_usage(
     schema=Invoice,
-    model=<span class="text-emerald-600">"xai:grok-4"</span>,
+    model=<span class="text-emerald-600">"xai:grok-4.3"</span>,
     input_file=path,
 )
 <span class="text-black/40">print(usage.total_tokens)</span></code></pre>
@@ -461,7 +461,7 @@
 
 <span class="text-black/70">result</span> <span class="text-black/40">=</span> <span class="text-black/70">extract</span>(
     <span class="text-black/40">schema=</span><span class="text-black/70">Report</span>,
-    <span class="text-black/40">model=</span><span class="text-emerald-600">"xai:grok-4"</span>,
+    <span class="text-black/40">model=</span><span class="text-emerald-600">"xai:grok-4.3"</span>,
     <span class="text-black/40">input_file=</span><span class="text-emerald-600">"https://example.com/report.pdf"</span>,
     <span class="text-black/40">instructions=</span><span class="text-emerald-600">"Extract findings"</span>,
 )</code></pre>

--- a/examples/batch_invoices.py
+++ b/examples/batch_invoices.py
@@ -46,7 +46,7 @@ def main() -> None:
 
     results = extract_many(
         schema=Invoice,
-        model="xai:grok-4",
+        model="xai:grok-4.3",
         input_files=paths,
         max_concurrency=5,
         instructions=(

--- a/examples/extract_with_usage.py
+++ b/examples/extract_with_usage.py
@@ -21,7 +21,7 @@ def main() -> None:
 
     result, usage = extract_with_usage(
         schema=PdfInfo,
-        model="xai:grok-4",
+        model="xai:grok-4.3",
         input_file=input_file,
         instructions="Return a two-sentence summary and the document's primary language.",
     )

--- a/examples/invoice_extraction.py
+++ b/examples/invoice_extraction.py
@@ -35,7 +35,7 @@ def main() -> None:
 
     invoice = extract(
         schema=Invoice,
-        model="xai:grok-4",
+        model="xai:grok-4.3",
         input_file=input_file,
         instructions=(
             "Extract the invoice metadata, parties, every line item, and the "

--- a/examples/meeting_notes.py
+++ b/examples/meeting_notes.py
@@ -31,7 +31,7 @@ def main() -> None:
 
     meeting = extract(
         schema=Meeting,
-        model="xai:grok-4",
+        model="xai:grok-4.3",
         input_file=input_file,
         instructions=(
             "Listen to the meeting audio and produce structured notes. Include "

--- a/examples/receipt_extraction.py
+++ b/examples/receipt_extraction.py
@@ -33,7 +33,7 @@ def main() -> None:
 
     receipt = extract(
         schema=Receipt,
-        model="xai:grok-4",
+        model="xai:grok-4.3",
         input_file=input_file,
         instructions=(
             "Read the receipt image and extract the merchant, transaction date, "

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -110,7 +110,7 @@ def bench_build_agent() -> None:
     print("\n[_build_agent] constructing a pydantic_ai.Agent")
     _bench(
         "_build_agent(non-ollama)",
-        lambda: _build_agent(_Person, "xai:grok-4", "extract"),
+        lambda: _build_agent(_Person, "xai:grok-4.3", "extract"),
         iters=200,
     )
     _bench(
@@ -137,8 +137,8 @@ def bench_extract_end_to_end(tmp: Path) -> None:
     print("\n[extract] sync extract() with Agent mocked (all-local cost per call)")
     with patch("openextract._extract.Agent", return_value=agent_instance):
         _bench(
-            "extract(path, xai:grok-4)",
-            lambda: extract(_Person, "xai:grok-4", str(src)),
+            "extract(path, xai:grok-4.3)",
+            lambda: extract(_Person, "xai:grok-4.3", str(src)),
             iters=500,
         )
 
@@ -156,7 +156,7 @@ def bench_extract_end_to_end(tmp: Path) -> None:
     with patch("openextract._extract.Agent", return_value=async_agent_instance):
         _bench(
             "extract_many(20 files, conc=5)",
-            lambda: extract_many(_Person, "xai:grok-4", files, max_concurrency=5),
+            lambda: extract_many(_Person, "xai:grok-4.3", files, max_concurrency=5),
             iters=20,
         )
 

--- a/src/openextract/_cli.py
+++ b/src/openextract/_cli.py
@@ -90,7 +90,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--model",
         required=True,
-        help="pydantic-ai model identifier (e.g. 'xai:grok-4').",
+        help="pydantic-ai model identifier (e.g. 'xai:grok-4.3').",
     )
     parser.add_argument(
         "--instructions",

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -50,6 +50,7 @@ _PROVIDER_ERROR_PATHS: tuple[tuple[str, str], ...] = (
     ("huggingface_hub.errors", "HfHubHTTPError"),
     ("groq", "APIError"),
     ("mistralai.client.errors.mistralerror", "MistralError"),
+    ("grpc", "RpcError"),  # xAI SDK uses gRPC; pydantic-ai may surface this directly
 )
 
 

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -418,7 +418,7 @@ def extract(
 
     Args:
         schema: A Pydantic model class defining the expected output structure.
-        model: The model identifier (e.g., 'xai:grok-4').
+        model: The model identifier (e.g., 'xai:grok-4.3').
         input_file: A local file path, an ``http(s)://`` URL, raw ``bytes``, or
             a binary file-like object with a ``.read()`` method. For ``bytes``
             and file-like inputs, ``media_type`` must be provided.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,7 +100,7 @@ class TestArgparse:
 
     def test_missing_schema_exits_nonzero(self, capsys):
         with pytest.raises(SystemExit) as exc_info:
-            main(["input.txt", "--model", "xai:grok-4"])
+            main(["input.txt", "--model", "xai:grok-4.3"])
         assert exc_info.value.code != 0
         captured = capsys.readouterr()
         assert "schema" in captured.err.lower()
@@ -120,7 +120,7 @@ class TestArgparse:
                     "--schema",
                     "tests.test_cli:_FixtureSchema",
                     "--model",
-                    "xai:grok-4",
+                    "xai:grok-4.3",
                     "--output",
                     "yaml",
                 ]
@@ -146,7 +146,7 @@ class TestMainSuccess:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "xai:grok-4",
+                "xai:grok-4.3",
                 "--instructions",
                 "find the person",
             ]
@@ -157,7 +157,7 @@ class TestMainSuccess:
         assert '"name": "Ada"' in captured.out
         mock_extract.assert_called_once_with(
             schema=_FixtureSchema,
-            model="xai:grok-4",
+            model="xai:grok-4.3",
             input_file="input.txt",
             instructions="find the person",
             media_type=None,
@@ -176,7 +176,7 @@ class TestMainSuccess:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "xai:grok-4",
+                "xai:grok-4.3",
                 "--output",
                 "repr",
             ]
@@ -197,7 +197,7 @@ class TestMainSuccess:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "xai:grok-4",
+                "xai:grok-4.3",
             ]
         )
 
@@ -215,7 +215,7 @@ class TestMainSuccess:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "xai:grok-4",
+                "xai:grok-4.3",
             ]
         )
 
@@ -233,7 +233,7 @@ class TestMainSuccess:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "xai:grok-4",
+                "xai:grok-4.3",
                 "--max-retries",
                 "3",
                 "--retry-backoff",
@@ -259,7 +259,7 @@ class TestMainErrorCodes:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "xai:grok-4",
+                "xai:grok-4.3",
             ]
         )
 
@@ -286,7 +286,7 @@ class TestMainErrorCodes:
                 "--schema",
                 "definitely_not_a_real_module_xyz:Thing",
                 "--model",
-                "xai:grok-4",
+                "xai:grok-4.3",
             ]
         )
         assert exit_code == 1
@@ -299,7 +299,7 @@ class TestMainErrorCodes:
                 "--schema",
                 "tests.test_cli:_NotASchema",
                 "--model",
-                "xai:grok-4",
+                "xai:grok-4.3",
             ]
         )
         assert exit_code == 1
@@ -324,7 +324,7 @@ class TestMainBatchAndUsage:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "xai:grok-4",
+                "xai:grok-4.3",
             ]
         )
 
@@ -347,7 +347,7 @@ class TestMainBatchAndUsage:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "xai:grok-4",
+                "xai:grok-4.3",
                 "--usage",
             ]
         )
@@ -366,7 +366,7 @@ class TestMainBatchAndUsage:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "xai:grok-4",
+                "xai:grok-4.3",
                 "--usage",
             ]
         )
@@ -381,7 +381,7 @@ class TestMainBatchAndUsage:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "xai:grok-4",
+                "xai:grok-4.3",
             ]
         )
         assert exit_code == 1
@@ -395,7 +395,7 @@ class TestMainBatchAndUsage:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "xai:grok-4",
+                "xai:grok-4.3",
                 "--media-type",
                 "application/pdf",
             ]
@@ -416,7 +416,7 @@ class TestMainBatchAndUsage:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "xai:grok-4",
+                "xai:grok-4.3",
                 "--media-type",
                 "application/pdf",
             ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,7 +100,7 @@ class TestArgparse:
 
     def test_missing_schema_exits_nonzero(self, capsys):
         with pytest.raises(SystemExit) as exc_info:
-            main(["input.txt", "--model", "openai:gpt-5"])
+            main(["input.txt", "--model", "xai:grok-4"])
         assert exc_info.value.code != 0
         captured = capsys.readouterr()
         assert "schema" in captured.err.lower()
@@ -120,7 +120,7 @@ class TestArgparse:
                     "--schema",
                     "tests.test_cli:_FixtureSchema",
                     "--model",
-                    "openai:gpt-5",
+                    "xai:grok-4",
                     "--output",
                     "yaml",
                 ]
@@ -146,7 +146,7 @@ class TestMainSuccess:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "openai:gpt-5",
+                "xai:grok-4",
                 "--instructions",
                 "find the person",
             ]
@@ -157,7 +157,7 @@ class TestMainSuccess:
         assert '"name": "Ada"' in captured.out
         mock_extract.assert_called_once_with(
             schema=_FixtureSchema,
-            model="openai:gpt-5",
+            model="xai:grok-4",
             input_file="input.txt",
             instructions="find the person",
             media_type=None,
@@ -176,7 +176,7 @@ class TestMainSuccess:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "openai:gpt-5",
+                "xai:grok-4",
                 "--output",
                 "repr",
             ]
@@ -197,7 +197,7 @@ class TestMainSuccess:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "openai:gpt-5",
+                "xai:grok-4",
             ]
         )
 
@@ -215,7 +215,7 @@ class TestMainSuccess:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "openai:gpt-5",
+                "xai:grok-4",
             ]
         )
 
@@ -233,7 +233,7 @@ class TestMainSuccess:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "openai:gpt-5",
+                "xai:grok-4",
                 "--max-retries",
                 "3",
                 "--retry-backoff",
@@ -259,7 +259,7 @@ class TestMainErrorCodes:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "openai:gpt-5",
+                "xai:grok-4",
             ]
         )
 
@@ -286,7 +286,7 @@ class TestMainErrorCodes:
                 "--schema",
                 "definitely_not_a_real_module_xyz:Thing",
                 "--model",
-                "openai:gpt-5",
+                "xai:grok-4",
             ]
         )
         assert exit_code == 1
@@ -299,7 +299,7 @@ class TestMainErrorCodes:
                 "--schema",
                 "tests.test_cli:_NotASchema",
                 "--model",
-                "openai:gpt-5",
+                "xai:grok-4",
             ]
         )
         assert exit_code == 1
@@ -324,7 +324,7 @@ class TestMainBatchAndUsage:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "openai:gpt-5",
+                "xai:grok-4",
             ]
         )
 
@@ -347,7 +347,7 @@ class TestMainBatchAndUsage:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "openai:gpt-5",
+                "xai:grok-4",
                 "--usage",
             ]
         )
@@ -366,7 +366,7 @@ class TestMainBatchAndUsage:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "openai:gpt-5",
+                "xai:grok-4",
                 "--usage",
             ]
         )
@@ -381,7 +381,7 @@ class TestMainBatchAndUsage:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "openai:gpt-5",
+                "xai:grok-4",
             ]
         )
         assert exit_code == 1
@@ -395,7 +395,7 @@ class TestMainBatchAndUsage:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "openai:gpt-5",
+                "xai:grok-4",
                 "--media-type",
                 "application/pdf",
             ]
@@ -416,7 +416,7 @@ class TestMainBatchAndUsage:
                 "--schema",
                 "tests.test_cli:_FixtureSchema",
                 "--model",
-                "openai:gpt-5",
+                "xai:grok-4",
                 "--media-type",
                 "application/pdf",
             ]

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -471,6 +471,20 @@ def _make_mistral_error(message: str) -> Exception:
     return _BareMistralError(message)
 
 
+def _make_grpc_error(message: str) -> Exception:
+    import grpc
+    from grpc import StatusCode
+
+    class _BareGrpcError(grpc.RpcError):
+        def code(self) -> grpc.StatusCode:
+            return StatusCode.RESOURCE_EXHAUSTED
+
+        def details(self) -> str:
+            return message
+
+    return _BareGrpcError()
+
+
 def _make_agent_mock(mocker, output=None, run_sync_side_effect=None, usage=None):
     """Patch openextract._extract.Agent and return (AgentClass, instance, run_sync)."""
     agent_instance = MagicMock()
@@ -595,6 +609,7 @@ class TestExtract:
                 "groq:llama-3.3-70b-versatile",
             ),
             (lambda msg: _make_mistral_error(msg), "mistral:mistral-large-latest"),
+            (lambda msg: _make_grpc_error(msg), "xai:grok-4"),
         ],
         ids=[
             "pydantic_ai_ModelHTTPError",
@@ -605,6 +620,7 @@ class TestExtract:
             "huggingface_HfHubHTTPError",
             "groq_APIError",
             "mistral_SDKError",
+            "xai_grpc_RpcError",
         ],
     )
     def test_provider_api_error_is_wrapped_as_model_error(

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -609,7 +609,7 @@ class TestExtract:
                 "groq:llama-3.3-70b-versatile",
             ),
             (lambda msg: _make_mistral_error(msg), "mistral:mistral-large-latest"),
-            (lambda msg: _make_grpc_error(msg), "xai:grok-4"),
+            (lambda msg: _make_grpc_error(msg), "xai:grok-4.3"),
         ],
         ids=[
             "pydantic_ai_ModelHTTPError",


### PR DESCRIPTION
## Summary

Adds xAI to the provider error test matrix and standardizes example model strings on `xai:grok-4.3`.

## Changes

- Classify `grpc.RpcError` as `ModelError` (xAI SDK gRPC failures)
- Parametrized test case `xai_grpc_RpcError` with model `xai:grok-4.3`
- CLI tests use `xai:grok-4.3` (mocked; OpenAI-specific extract tests unchanged)
- Examples, README, docs landing page, CLI help, and bench script use `xai:grok-4.3`

## Verification

```bash
uv run pytest -q  # 141 passed
```