### PR TITLE
feat: actionable error when a provider extra is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- `ProviderNotInstalledError` (a subclass of `ExtractionError`) raised with an
+  actionable `pip install openextract[...]` hint when a model is requested whose
+  provider extra is not installed. The CLI reports it with exit code `6`.
+
 ## [0.8.0] - 2026-06-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ from openextract import (
     UrlFetchError,
     SchemaValidationError,
     ModelError,
+    ProviderNotInstalledError,
     ExtractionError,
 )
 
@@ -238,6 +239,8 @@ except UrlFetchError:
     ...  # The URL could not be fetched
 except SchemaValidationError:
     ...  # The model's output did not match your schema
+except ProviderNotInstalledError:
+    ...  # The provider extra isn't installed (e.g. pip install openextract[xai])
 except ModelError:
     ...  # The model provider returned an error
 except ExtractionError:

--- a/src/openextract/__init__.py
+++ b/src/openextract/__init__.py
@@ -11,7 +11,13 @@ from ._extract import (
     extract_with_usage,
     extract_with_usage_async,
 )
-from .exceptions import ExtractionError, ModelError, SchemaValidationError, UrlFetchError
+from .exceptions import (
+    ExtractionError,
+    ModelError,
+    ProviderNotInstalledError,
+    SchemaValidationError,
+    UrlFetchError,
+)
 
 __all__ = [
     "extract",
@@ -23,6 +29,7 @@ __all__ = [
     "Usage",
     "ExtractionError",
     "ModelError",
+    "ProviderNotInstalledError",
     "SchemaValidationError",
     "UrlFetchError",
 ]

--- a/src/openextract/_cli.py
+++ b/src/openextract/_cli.py
@@ -12,7 +12,13 @@ from typing import Any, cast
 from pydantic import BaseModel
 
 from ._extract import extract, extract_many, extract_with_usage
-from .exceptions import ExtractionError, ModelError, SchemaValidationError, UrlFetchError
+from .exceptions import (
+    ExtractionError,
+    ModelError,
+    ProviderNotInstalledError,
+    SchemaValidationError,
+    UrlFetchError,
+)
 
 
 def _resolve_schema(schema_path: str) -> type[BaseModel]:
@@ -198,6 +204,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     except ModelError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 4
+    except ProviderNotInstalledError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 6
     except ExtractionError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 5

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -21,7 +21,13 @@ from pydantic import BaseModel, ValidationError
 from pydantic_ai import Agent, BinaryContent
 from pydantic_ai.output import NativeOutput
 
-from .exceptions import ExtractionError, ModelError, SchemaValidationError, UrlFetchError
+from .exceptions import (
+    ExtractionError,
+    ModelError,
+    ProviderNotInstalledError,
+    SchemaValidationError,
+    UrlFetchError,
+)
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -52,6 +58,26 @@ _PROVIDER_ERROR_PATHS: tuple[tuple[str, str], ...] = (
     ("mistralai.client.errors.mistralerror", "MistralError"),
     ("grpc", "RpcError"),  # xAI SDK uses gRPC; pydantic-ai may surface this directly
 )
+
+# pydantic-ai model-id prefix -> the openextract optional-dependency extra that
+# installs that provider's SDK. OpenAI-compatible providers (Cerebras, Ollama)
+# ship through the openai SDK, so they map to the ``openai`` extra. Prefixes not
+# listed here fall back to suggesting ``openextract[all]``.
+_PROVIDER_EXTRAS: dict[str, str] = {
+    "openai": "openai",
+    "anthropic": "anthropic",
+    "google-gla": "google",
+    "google-vertex": "google",
+    "bedrock": "bedrock",
+    "cohere": "cohere",
+    "groq": "groq",
+    "huggingface": "huggingface",
+    "mistral": "mistral",
+    "openrouter": "openrouter",
+    "xai": "xai",
+    "cerebras": "openai",
+    "ollama": "openai",
+}
 
 
 def _collect_model_error_types() -> tuple[type[BaseException], ...]:
@@ -263,13 +289,33 @@ def _get_media(
     )
 
 
+def _install_hint(model: str) -> str:
+    """Return the ``pip install`` command that provides ``model``'s provider."""
+    prefix = model.split(":", 1)[0]
+    extra = _PROVIDER_EXTRAS.get(prefix)
+    target = f"openextract[{extra}]" if extra else "openextract[all]"
+    return f"pip install '{target}'"
+
+
 def _build_agent(schema: type[T], model: str, instructions: str | None) -> Agent:
-    """Construct the pydantic_ai Agent, handling the ollama output-type quirk."""
-    return Agent(
-        model,
-        instructions=instructions,
-        output_type=NativeOutput(schema) if model.startswith("ollama") else schema,
-    )
+    """Construct the pydantic_ai Agent, handling the ollama output-type quirk.
+
+    A missing provider SDK surfaces here as ``ImportError`` (pydantic-ai infers
+    the model eagerly); translate it into an actionable
+    :class:`ProviderNotInstalledError`.
+    """
+    try:
+        return Agent(
+            model,
+            instructions=instructions,
+            output_type=NativeOutput(schema) if model.startswith("ollama") else schema,
+        )
+    except ImportError as exc:
+        raise ProviderNotInstalledError(
+            f"Model {model!r} needs a provider SDK that is not installed. "
+            f"Install it with: {_install_hint(model)} "
+            f"(or 'pip install openextract[all]'). Original error: {exc}"
+        ) from exc
 
 
 def _build_run_inputs(file_bytes: bytes, file_type: str) -> list:

--- a/src/openextract/exceptions.py
+++ b/src/openextract/exceptions.py
@@ -9,6 +9,15 @@ class ModelError(ExtractionError):
     """Error communicating with the model API."""
 
 
+class ProviderNotInstalledError(ExtractionError):
+    """The SDK for the requested model's provider is not installed.
+
+    Raised when a model is requested whose provider extra was not installed,
+    e.g. calling ``extract(..., model="openai:gpt-4o")`` without first running
+    ``pip install 'openextract[openai]'``.
+    """
+
+
 class SchemaValidationError(ExtractionError):
     """Model output did not match the expected schema."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from openextract import (
     ExtractionError,
     ModelError,
+    ProviderNotInstalledError,
     SchemaValidationError,
     UrlFetchError,
 )
@@ -278,6 +279,11 @@ class TestMainErrorCodes:
     def test_extraction_error_returns_5(self, mocker, capsys):
         assert self._invoke(mocker, ExtractionError("misc")) == 5
         assert "misc" in capsys.readouterr().err
+
+    def test_provider_not_installed_error_returns_6(self, mocker, capsys):
+        exc = ProviderNotInstalledError("install openextract[openai]")
+        assert self._invoke(mocker, exc) == 6
+        assert "openextract[openai]" in capsys.readouterr().err
 
     def test_bad_schema_module_returns_1(self, capsys):
         exit_code = main(

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -15,6 +15,7 @@ from pydantic_ai import BinaryContent
 from openextract import (
     ExtractionError,
     ModelError,
+    ProviderNotInstalledError,
     SchemaValidationError,
     UrlFetchError,
     Usage,
@@ -29,6 +30,7 @@ from openextract._extract import (
     _fetch_url,
     _get_media,
     _get_media_type,
+    _install_hint,
     _is_public_ip,
     _is_safe_host,
     _max_redirects,
@@ -80,6 +82,7 @@ def test_star_import_exposes_only_existing_names():
         "Usage",
         "ExtractionError",
         "ModelError",
+        "ProviderNotInstalledError",
         "SchemaValidationError",
         "UrlFetchError",
     }
@@ -689,6 +692,46 @@ class TestExtract:
 
         assert result is expected
         assert not isinstance(result, tuple)
+
+
+# ---------------------------------------------------------------------------
+# Provider-not-installed guardrail
+# ---------------------------------------------------------------------------
+
+
+class TestProviderNotInstalled:
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            ("openai:gpt-4o", "openextract[openai]"),
+            ("anthropic:claude-sonnet-4-20250514", "openextract[anthropic]"),
+            ("google-gla:gemini-2.5-flash", "openextract[google]"),
+            ("xai:grok-4.3", "openextract[xai]"),
+            ("cerebras:llama-3.3-70b", "openextract[openai]"),
+            ("ollama:llama3.2", "openextract[openai]"),
+            ("madeup:model", "openextract[all]"),
+        ],
+    )
+    def test_install_hint_maps_prefix_to_extra(self, model, expected):
+        assert _install_hint(model) == f"pip install '{expected}'"
+
+    def test_missing_provider_raises_provider_not_installed_error(self, tmp_path, mocker):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hello")
+        mocker.patch(
+            "openextract._extract.Agent",
+            side_effect=ImportError("No module named 'openai'"),
+        )
+
+        with pytest.raises(ProviderNotInstalledError) as exc_info:
+            extract(schema=_Person, model="openai:gpt-4o", input_file=str(local))
+
+        message = str(exc_info.value)
+        assert "openextract[openai]" in message
+        assert "No module named 'openai'" in message
+
+    def test_provider_not_installed_is_extraction_error(self):
+        assert issubclass(ProviderNotInstalledError, ExtractionError)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

0.8.0 moved provider SDKs to optional extras (#101), so a fresh `pip install openextract` ships no providers. Calling `extract(..., model="openai:gpt-4o")` without the matching extra surfaced a raw `ImportError` from deep inside pydantic-ai — a confusing install cliff with no pointer to the fix.

## What

- Add `ProviderNotInstalledError(ExtractionError)`, exported from the package.
- Catch `ImportError` at agent construction (pydantic-ai infers the model eagerly) and re-raise it with the exact remedy, e.g. `pip install 'openextract[openai]'`. Unknown prefixes fall back to `openextract[all]`. OpenAI-compatible providers (Cerebras, Ollama) point at the `openai` extra.
- CLI reports the new error with a dedicated exit code `6`.
- Docs: error-handling example and CHANGELOG.

## Tests

`_install_hint` prefix→extra mapping (parametrized), `_build_agent` ImportError translation including the hint and original message, subclass relationship, and the CLI exit code. Full suite green (151 passed), ruff and ty clean.