### PR TITLE
feat: add --continue-on-error to CLI batch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- `--continue-on-error` flag on the `openextract` CLI: in batch mode, keep
+  processing remaining inputs when one fails, emit per-item errors inline, and
+  exit `7` if any input failed (default remains abort-on-first-failure).
+
 ## [0.8.0] - 2026-06-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -197,9 +197,13 @@ cat ./reports/q4.pdf | openextract - \
 - `--usage` prints a JSON object with `result` and `usage` (single input only).
 - `--output` is `json` (default) or `repr`.
 - `--max-retries` / `--retry-backoff` match the Python API retry behavior.
+- `--continue-on-error` (batch only) keeps processing when an input fails; each
+  failure is emitted inline as `{"input", "error", "error_type"}` and the command
+  exits `7` if any input failed. Without it, a batch aborts on the first failure.
 
 Exit codes: `0` success, `2` URL fetch error, `3` schema validation error, `4` model error,
-`5` other extraction error, `1` any other failure (including bad `--schema` paths).
+`5` other extraction error, `7` partial batch failure (`--continue-on-error`),
+`1` any other failure (including bad `--schema` paths).
 
 ## Examples
 

--- a/src/openextract/_cli.py
+++ b/src/openextract/_cli.py
@@ -64,6 +64,30 @@ def _usage_payload(usage) -> dict[str, int]:
     }
 
 
+def _batch_payload(results: list, inputs: list[str | bytes]) -> tuple[list[Any], int]:
+    """Build the JSON entries for a batch run and count per-item failures.
+
+    Successful items serialize to their model dump. Failed items (only present
+    when ``--continue-on-error`` runs the batch with ``return_exceptions=True``)
+    become an error object tagged with the originating input.
+    """
+    payload: list[Any] = []
+    failures = 0
+    for item, result in zip(inputs, results, strict=True):
+        if isinstance(result, BaseException):
+            failures += 1
+            payload.append(
+                {
+                    "input": item if isinstance(item, str) else "<bytes>",
+                    "error": str(result),
+                    "error_type": type(result).__name__,
+                }
+            )
+        else:
+            payload.append(result.model_dump())
+    return payload, failures
+
+
 def _print_json(payload: Any, *, as_repr: bool) -> None:
     if as_repr:
         print(repr(payload))
@@ -107,6 +131,14 @@ def _build_parser() -> argparse.ArgumentParser:
         "--usage",
         action="store_true",
         help="Print token usage (single input only).",
+    )
+    parser.add_argument(
+        "--continue-on-error",
+        action="store_true",
+        help=(
+            "Batch only: keep going when an input fails; report per-item errors "
+            "inline and exit 7 if any failed (default: abort on first failure)."
+        ),
     )
     parser.add_argument(
         "--output",
@@ -153,6 +185,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 1
 
     media_type = args.media_type
+    batch_failures = 0
 
     try:
         if len(input_files) == 1:
@@ -187,8 +220,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                 media_type=media_type,
                 max_retries=args.max_retries,
                 retry_backoff=args.retry_backoff,
+                return_exceptions=args.continue_on_error,
             )
-            payload = [r.model_dump() for r in results]
+            payload, batch_failures = _batch_payload(results, input_files)
     except UrlFetchError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
@@ -208,6 +242,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(payload.model_dump_json(indent=2))
     else:
         _print_json(payload, as_repr=False)
+
+    if batch_failures:
+        print(
+            f"warning: {batch_failures} of {len(input_files)} input(s) failed; "
+            "see output for details",
+            file=sys.stderr,
+        )
+        return 7  # partial batch failure under --continue-on-error
     return 0
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -333,6 +333,87 @@ class TestMainBatchAndUsage:
         captured = capsys.readouterr()
         assert '"name": "Ada"' in captured.out
 
+    def test_batch_defaults_to_abort_on_first_failure(self, mocker):
+        fake = MagicMock()
+        fake.model_dump.return_value = {"name": "Ada", "age": 36}
+        mock_many = _patch_extract_many(mocker, return_value=[fake, fake])
+
+        main(
+            [
+                "a.pdf",
+                "b.pdf",
+                "--schema",
+                "tests.test_cli:_FixtureSchema",
+                "--model",
+                "xai:grok-4.3",
+            ]
+        )
+
+        assert mock_many.call_args.kwargs["return_exceptions"] is False
+
+    def test_continue_on_error_passes_return_exceptions(self, mocker):
+        fake = MagicMock()
+        fake.model_dump.return_value = {"name": "Ada", "age": 36}
+        mock_many = _patch_extract_many(mocker, return_value=[fake, fake])
+
+        main(
+            [
+                "a.pdf",
+                "b.pdf",
+                "--schema",
+                "tests.test_cli:_FixtureSchema",
+                "--model",
+                "xai:grok-4.3",
+                "--continue-on-error",
+            ]
+        )
+
+        assert mock_many.call_args.kwargs["return_exceptions"] is True
+
+    def test_continue_on_error_reports_failures_and_exits_7(self, mocker, capsys):
+        fake = MagicMock()
+        fake.model_dump.return_value = {"name": "Ada", "age": 36}
+        _patch_extract_many(mocker, return_value=[fake, ModelError("boom")])
+
+        exit_code = main(
+            [
+                "a.pdf",
+                "b.pdf",
+                "--schema",
+                "tests.test_cli:_FixtureSchema",
+                "--model",
+                "xai:grok-4.3",
+                "--continue-on-error",
+            ]
+        )
+
+        assert exit_code == 7
+        captured = capsys.readouterr()
+        assert '"name": "Ada"' in captured.out  # the successful item is still emitted
+        assert '"error_type": "ModelError"' in captured.out
+        assert '"input": "b.pdf"' in captured.out
+        assert "1 of 2 input(s) failed" in captured.err
+
+    def test_continue_on_error_all_success_exits_0(self, mocker, capsys):
+        fake = MagicMock()
+        fake.model_dump.return_value = {"name": "Ada", "age": 36}
+        _patch_extract_many(mocker, return_value=[fake, fake])
+
+        exit_code = main(
+            [
+                "a.pdf",
+                "b.pdf",
+                "--schema",
+                "tests.test_cli:_FixtureSchema",
+                "--model",
+                "xai:grok-4.3",
+                "--continue-on-error",
+            ]
+        )
+
+        assert exit_code == 0
+        assert capsys.readouterr().err == ""
+
     def test_usage_flag_calls_extract_with_usage(self, mocker, capsys):
         from openextract import Usage
 


### PR DESCRIPTION
## Why

Batch extraction (`openextract a.pdf b.pdf ...`) calls `extract_many` with the default `return_exceptions=False`, so a single failing input aborts the whole run and discards every already-completed result — a sharp edge for the batch use case introduced in #103.

## What

- Add `--continue-on-error` (batch only). It runs `extract_many` with `return_exceptions=True`, emits each failure inline as `{"input", "error", "error_type"}` next to the successful results, prints a one-line stderr summary, and exits `7` if any input failed.
- Default behavior is unchanged: without the flag, a batch still aborts on the first failure with the existing mapped exit code.
- Docs: CLI flag, exit-code table, CHANGELOG.

Exit code `7` is used for partial failure to avoid colliding with exit `6` reserved by #108 (provider-not-installed); the two PRs are independent and can merge in either order.

## Tests

Default passes `return_exceptions=False`; the flag passes `True`; a mixed success/failure batch exits `7` with the failure surfaced inline and a stderr summary; an all-success batch exits `0`. Full suite green (145 passed), ruff and ty clean.