### PR TITLE
docs: clean up landing page UI

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -50,11 +50,6 @@
         background-size: 60px 60px;
       }
 
-      /* Hero glow */
-      .hero-glow {
-        background: radial-gradient(ellipse 60% 40% at 50% -10%, rgba(0, 0, 0, 0.04), transparent);
-      }
-
       /* Scrollbar */
       ::-webkit-scrollbar { width: 6px; }
       ::-webkit-scrollbar-track { background: #fafafa; }
@@ -79,7 +74,7 @@
           <div class="w-8 h-8 bg-black flex items-center justify-center">
             <span class="text-white font-mono font-bold text-xs">OE</span>
           </div>
-          <span class="font-mono text-sm text-black/80 hidden sm:inline">openextract</span>
+          <span class="font-mono text-sm text-black/60 hidden sm:inline">openextract</span>
         </a>
 
         <nav class="flex items-center gap-4 sm:gap-6">
@@ -92,65 +87,62 @@
     <main>
 
       <!-- Hero Section -->
-      <section class="relative min-h-screen flex items-center justify-center hero-glow pt-14">
+      <section class="relative min-h-screen flex items-center justify-center pt-14">
         <div class="max-w-3xl mx-auto px-4 sm:px-6 py-16 sm:py-24 text-center">
 
           <!-- Badge -->
           <a href="#whats-new" class="animate-slide-up opacity-0 inline-flex items-center gap-2.5 px-3 py-1.5 border border-black/10 bg-white text-xs mb-8 hover:border-black/30 transition-colors">
             <span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>
-            <span class="font-mono text-black/50">v0.8.0</span>
-            <span class="text-black/30">|</span>
-            <span class="text-black/50">optional extras, CLI batch, retry parity</span>
+            <span class="font-mono text-black/40">v0.8.0</span>
+            <span class="text-black/40">|</span>
+            <span class="text-black/40">optional extras, CLI batch, retry parity</span>
           </a>
 
           <!-- Headline -->
-          <h1 class="animate-slide-up opacity-0 [animation-delay:100ms] text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight mb-4 sm:mb-6 bg-gradient-to-b from-black to-black/50 bg-clip-text text-transparent">
+          <h1 class="animate-slide-up opacity-0 [animation-delay:100ms] text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight mb-4 sm:mb-6 bg-gradient-to-b from-black to-black/60 bg-clip-text text-transparent">
             Structured Extraction
           </h1>
 
           <!-- Subheadline -->
-          <p class="animate-slide-up opacity-0 [animation-delay:150ms] text-base sm:text-lg text-black/50 mb-2 sm:mb-3 font-mono">
+          <p class="text-base sm:text-lg text-black/60 mb-2 sm:mb-3 font-mono">
             Typed output from any media.
           </p>
-          <p class="animate-slide-up opacity-0 [animation-delay:200ms] text-sm text-black/40 max-w-md mx-auto mb-8 sm:mb-10 px-2">
+          <p class="text-sm text-black/40 max-w-md mx-auto mb-8 sm:mb-10 px-2">
             Extract structured data from documents, images, audio, and video using LLMs and Pydantic schemas.
           </p>
 
           <!-- CTAs -->
-          <div class="animate-slide-up opacity-0 [animation-delay:250ms] flex flex-col sm:flex-row gap-3 justify-center mb-10 sm:mb-14">
+          <div class="flex flex-col sm:flex-row gap-3 justify-center mb-10 sm:mb-14">
             <a href="https://github.com/Mellow-Artificial-Intelligence/openextract"
                class="h-10 px-5 bg-white border border-black/10 text-black font-medium text-sm flex items-center justify-center hover:bg-black/5 hover:border-black/20 transition-colors">
                View Source
             </a>
-            <button onclick="copyInstall()" class="h-10 px-3 sm:px-4 bg-white border border-black/10 text-black/70 font-mono text-xs sm:text-sm flex items-center justify-center gap-2 sm:gap-3 hover:bg-black/5 hover:border-black/20 transition-all group">
-              <span class="text-black/30">$</span> <span class="truncate">uv add openextract</span>
-              <span id="copy-icon" class="text-black/30 group-hover:text-black/50 flex-shrink-0"><i data-lucide="copy" class="w-3.5 h-3.5"></i></span>
+            <button onclick="copyInstall()" class="h-10 px-3 sm:px-4 bg-white border border-black/10 text-black/60 font-mono text-xs sm:text-sm flex items-center justify-center gap-2 sm:gap-3 hover:bg-black/5 hover:border-black/20 transition-all group">
+              <span class="text-black/40">$</span> <span class="truncate">uv add openextract</span>
+              <span id="copy-icon" class="text-black/40 group-hover:text-black/60 flex-shrink-0"><i data-lucide="copy" class="w-3.5 h-3.5"></i></span>
               <span id="check-icon" class="hidden text-emerald-500 flex-shrink-0"><i data-lucide="check" class="w-3.5 h-3.5"></i></span>
             </button>
           </div>
 
-          <!-- Code Preview -->
-          <div class="animate-slide-up opacity-0 [animation-delay:300ms] max-w-lg mx-auto">
+          <!-- Terminal preview -->
+          <div class="max-w-lg mx-auto mb-8 sm:mb-10">
             <div class="code-block overflow-hidden text-left">
               <div class="px-3 sm:px-4 py-2.5 border-b border-black/5 flex items-center justify-between">
-                <span class="font-mono text-[10px] text-black/30 uppercase tracking-wider">Terminal</span>
-                <span class="font-mono text-[10px] text-black/20">extract.py</span>
+                <span class="font-mono text-[10px] text-black/40 uppercase tracking-wider">Terminal</span>
+                <span class="font-mono text-[10px] text-black/40">install</span>
               </div>
               <div class="p-3 sm:p-4 overflow-x-auto">
-<pre class="text-xs sm:text-sm font-mono leading-relaxed"><code><span class="text-black/40">from</span> <span class="text-black/70">openextract</span> <span class="text-black/40">import</span> <span class="text-black/70">extract</span>
-
-<span class="text-black/70">result</span> <span class="text-black/40">=</span> <span class="text-black/70">extract</span>(
-    <span class="text-black/40">schema=</span><span class="text-black/70">Invoice</span>,
-    <span class="text-black/40">model=</span><span class="text-emerald-600">"xai:grok-4.3"</span>,
-    <span class="text-black/40">input_file=</span><span class="text-emerald-600">"https://example.com/doc.pdf"</span>,
-    <span class="text-black/40">instructions=</span><span class="text-emerald-600">"Extract invoice data"</span>,
-)</code></pre>
+<pre class="text-xs sm:text-sm font-mono leading-relaxed"><code><span class="text-black/40">$</span> <span class="text-black/90">uv add openextract</span>
+<span class="text-black/40">$</span> <span class="text-black/90">openextract report.pdf \</span>
+    <span class="text-black/90">--schema mypkg:Invoice \</span>
+    <span class="text-black/90">--model</span> <span class="text-emerald-600">xai:grok-4.3</span>
+<span class="text-black/40">{ "total": 1240.00, "currency": "USD", ... }</span></code></pre>
               </div>
             </div>
           </div>
 
           <!-- Tech badges -->
-          <div class="animate-slide-up opacity-0 [animation-delay:400ms] flex flex-wrap justify-center gap-3 sm:gap-4 mt-6 sm:mt-8 font-mono text-[10px] sm:text-[11px] text-black/30">
+          <div class="flex flex-wrap justify-center gap-3 sm:gap-4 font-mono text-[10px] sm:text-[11px] text-black/40">
             <span class="flex items-center gap-1.5"><i data-lucide="shield-check" class="w-3 h-3"></i> Pydantic</span>
             <span class="flex items-center gap-1.5"><i data-lucide="cpu" class="w-3 h-3"></i> Any LLM</span>
           </div>
@@ -158,248 +150,48 @@
       </section>
 
       <!-- Features -->
-      <section class="py-16 sm:py-24 border-t border-black/5">
+      <section class="pt-10 sm:pt-14 pb-16 sm:pb-24 border-t border-black/5">
         <div class="max-w-5xl mx-auto px-4 sm:px-6">
           <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
 
             <div class="p-5 border border-black/10 bg-white">
               <div class="w-9 h-9 border border-black/10 flex items-center justify-center mb-4">
-                <i data-lucide="zap" class="w-4 h-4 text-black/50"></i>
+                <i data-lucide="zap" class="w-4 h-4 text-black/40"></i>
               </div>
-              <h3 class="font-mono text-sm font-medium text-black/80 mb-2">Zero Config</h3>
-              <p class="text-sm text-black/40 leading-relaxed">
+              <h3 class="font-mono text-sm font-medium text-black/90 mb-2">Zero Config</h3>
+              <p class="text-sm text-black/60 leading-relaxed">
                 One function call. Bring a schema, a URL, and an LLM model string.
               </p>
             </div>
 
             <div class="p-5 border border-black/10 bg-white">
               <div class="w-9 h-9 border border-black/10 flex items-center justify-center mb-4">
-                <i data-lucide="files" class="w-4 h-4 text-black/50"></i>
+                <i data-lucide="files" class="w-4 h-4 text-black/40"></i>
               </div>
-              <h3 class="font-mono text-sm font-medium text-black/80 mb-2">Multi-Media</h3>
-              <p class="text-sm text-black/40 leading-relaxed">
+              <h3 class="font-mono text-sm font-medium text-black/90 mb-2">Multi-Media</h3>
+              <p class="text-sm text-black/60 leading-relaxed">
                 Documents, images, audio, and video with smart routing.
               </p>
             </div>
 
             <div class="p-5 border border-black/10 bg-white">
               <div class="w-9 h-9 border border-black/10 flex items-center justify-center mb-4">
-                <i data-lucide="cpu" class="w-4 h-4 text-black/50"></i>
+                <i data-lucide="cpu" class="w-4 h-4 text-black/40"></i>
               </div>
-              <h3 class="font-mono text-sm font-medium text-black/80 mb-2">Any LLM</h3>
-              <p class="text-sm text-black/40 leading-relaxed">
+              <h3 class="font-mono text-sm font-medium text-black/90 mb-2">Any LLM</h3>
+              <p class="text-sm text-black/60 leading-relaxed">
                 11 providers wired in: OpenAI, Anthropic, Google, AWS Bedrock, xAI, Cohere, Hugging Face, Groq, Mistral, OpenRouter, and Ollama.
               </p>
             </div>
 
             <div class="p-5 border border-black/10 bg-white">
               <div class="w-9 h-9 border border-black/10 flex items-center justify-center mb-4">
-                <i data-lucide="check-circle" class="w-4 h-4 text-black/50"></i>
+                <i data-lucide="check-circle" class="w-4 h-4 text-black/40"></i>
               </div>
-              <h3 class="font-mono text-sm font-medium text-black/80 mb-2">Type Safe</h3>
-              <p class="text-sm text-black/40 leading-relaxed">
+              <h3 class="font-mono text-sm font-medium text-black/90 mb-2">Type Safe</h3>
+              <p class="text-sm text-black/60 leading-relaxed">
                 Pydantic schemas ensure validated, typed output every time.
               </p>
-            </div>
-
-          </div>
-        </div>
-      </section>
-
-      <!-- What's new in 0.8.0 -->
-      <section id="whats-new" class="py-16 sm:py-24 border-t border-black/5 scroll-mt-14">
-        <div class="max-w-5xl mx-auto px-4 sm:px-6">
-          <div class="flex items-baseline justify-between mb-8 sm:mb-10 flex-wrap gap-3">
-            <div>
-              <p class="font-mono text-[11px] text-black/30 uppercase tracking-wider mb-2">What&rsquo;s new</p>
-              <h2 class="text-2xl sm:text-3xl font-bold text-black/90">v0.8.0</h2>
-            </div>
-            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/CHANGELOG.md#080---2026-06-02" class="font-mono text-xs text-black/40 hover:text-black/70 transition-colors inline-flex items-center gap-1.5">
-              Full changelog <i data-lucide="arrow-up-right" class="w-3 h-3"></i>
-            </a>
-          </div>
-
-          <div class="p-6 border border-black/10 bg-white mb-3 sm:mb-4">
-            <div class="flex items-center gap-3 mb-3">
-              <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
-                <i data-lucide="package" class="w-4 h-4 text-black/50"></i>
-              </div>
-              <span class="font-mono text-[10px] text-black/30 uppercase tracking-wider">v0.8.0 &middot; Install</span>
-            </div>
-            <h3 class="font-mono text-base font-medium text-black/80 mb-2">Slim core, optional provider extras</h3>
-            <p class="text-sm text-black/40 leading-relaxed mb-4">
-              <code class="font-mono text-black/60 text-xs">pip install openextract</code> and <code class="font-mono text-black/60 text-xs">uv add openextract</code> ship a lean dependency set. Add the SDK you need for model calls &mdash; for example <code class="font-mono text-black/60 text-xs">openextract[openai]</code> or <code class="font-mono text-black/60 text-xs">openextract[all]</code>.
-            </p>
-            <div class="flex flex-wrap gap-1.5">
-              <span class="font-mono text-[11px] text-black/60 border border-black/10 px-2 py-1">[openai]</span>
-              <span class="font-mono text-[11px] text-black/60 border border-black/10 px-2 py-1">[anthropic]</span>
-              <span class="font-mono text-[11px] text-black/60 border border-black/10 px-2 py-1">[google]</span>
-              <span class="font-mono text-[11px] text-black/60 border border-black/10 px-2 py-1">[bedrock]</span>
-              <span class="font-mono text-[11px] text-black/60 border border-black/10 px-2 py-1">[groq]</span>
-              <span class="font-mono text-[11px] text-black/60 border border-black/10 px-2 py-1">[mistral]</span>
-              <span class="font-mono text-[11px] text-black/60 border border-black/10 px-2 py-1">[all]</span>
-            </div>
-          </div>
-
-          <p class="font-mono text-[11px] text-black/30 uppercase tracking-wider mt-8 mb-3">Also in v0.8.0</p>
-
-          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4 mb-8">
-
-            <div class="p-5 border border-black/10 bg-white">
-              <div class="flex items-center gap-3 mb-3">
-                <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
-                  <i data-lucide="refresh-cw" class="w-4 h-4 text-black/50"></i>
-                </div>
-                <span class="font-mono text-[10px] text-black/30 uppercase tracking-wider">Reliability</span>
-              </div>
-              <h3 class="font-mono text-sm font-medium text-black/80 mb-2">Retry everywhere</h3>
-              <p class="text-sm text-black/40 leading-relaxed mb-3">
-                <code class="font-mono text-black/60 text-xs">max_retries</code> and <code class="font-mono text-black/60 text-xs">retry_backoff</code> on async, usage, and batch extract APIs &mdash; same semantics as <code class="font-mono text-black/60 text-xs">extract()</code>.
-              </p>
-            </div>
-
-            <div class="p-5 border border-black/10 bg-white">
-              <div class="flex items-center gap-3 mb-3">
-                <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
-                  <i data-lucide="terminal" class="w-4 h-4 text-black/50"></i>
-                </div>
-                <span class="font-mono text-[10px] text-black/30 uppercase tracking-wider">CLI</span>
-              </div>
-              <h3 class="font-mono text-sm font-medium text-black/80 mb-2">Batch, usage, stdin</h3>
-              <p class="text-sm text-black/40 leading-relaxed mb-3">
-                Multiple files per run, <code class="font-mono text-black/60 text-xs">--usage</code>, <code class="font-mono text-black/60 text-xs">--media-type</code>, and pipe from <code class="font-mono text-black/60 text-xs">-</code>.
-              </p>
-              <pre class="text-[11px] font-mono leading-relaxed text-black/60 bg-black/5 p-2.5 overflow-x-auto"><code><span class="text-black/40">$</span> openextract a.pdf b.pdf \
-    --schema mypkg:Invoice \
-    --model <span class="text-emerald-600">xai:grok-4.3</span> \
-    --usage</code></pre>
-            </div>
-
-            <div class="p-5 border border-black/10 bg-white">
-              <div class="flex items-center gap-3 mb-3">
-                <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
-                  <i data-lucide="globe" class="w-4 h-4 text-black/50"></i>
-                </div>
-                <span class="font-mono text-[10px] text-black/30 uppercase tracking-wider">URLs</span>
-              </div>
-              <h3 class="font-mono text-sm font-medium text-black/80 mb-2">Fetch tuning</h3>
-              <p class="text-sm text-black/40 leading-relaxed mb-3">
-                Configure HTTP timeout and redirect limits with <code class="font-mono text-black/60 text-xs">OPENEXTRACT_URL_TIMEOUT</code> and <code class="font-mono text-black/60 text-xs">OPENEXTRACT_MAX_REDIRECTS</code>.
-              </p>
-            </div>
-
-          </div>
-
-          <p class="font-mono text-[11px] text-black/30 uppercase tracking-wider mt-8 mb-3">Carried forward from earlier releases</p>
-
-          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4">
-
-            <div class="p-5 border border-black/10 bg-white">
-              <div class="flex items-center gap-3 mb-3">
-                <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
-                  <i data-lucide="git-branch" class="w-4 h-4 text-black/50"></i>
-                </div>
-                <span class="font-mono text-[10px] text-black/30 uppercase tracking-wider">Concurrency</span>
-              </div>
-              <h3 class="font-mono text-sm font-medium text-black/80 mb-2">Async &amp; batch</h3>
-              <p class="text-sm text-black/40 leading-relaxed mb-3">
-                <code class="font-mono text-black/60 text-xs">extract_async</code>, <code class="font-mono text-black/60 text-xs">extract_many</code>, and <code class="font-mono text-black/60 text-xs">extract_many_async</code> for concurrent runs with an explicit limit.
-              </p>
-              <pre class="text-[11px] font-mono leading-relaxed text-black/60 bg-black/5 p-2.5 overflow-x-auto"><code>results = extract_many(
-    schema=Invoice,
-    model=<span class="text-emerald-600">"xai:grok-4.3"</span>,
-    input_files=paths,
-    max_concurrency=<span class="text-emerald-600">5</span>,
-)</code></pre>
-            </div>
-
-            <div class="p-5 border border-black/10 bg-white">
-              <div class="flex items-center gap-3 mb-3">
-                <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
-                  <i data-lucide="file-input" class="w-4 h-4 text-black/50"></i>
-                </div>
-                <span class="font-mono text-[10px] text-black/30 uppercase tracking-wider">Inputs</span>
-              </div>
-              <h3 class="font-mono text-sm font-medium text-black/80 mb-2">Bytes &amp; file-like</h3>
-              <p class="text-sm text-black/40 leading-relaxed mb-3">
-                Pass raw <code class="font-mono text-black/60 text-xs">bytes</code> or any <code class="font-mono text-black/60 text-xs">BinaryIO</code>. No temp file dance.
-              </p>
-              <pre class="text-[11px] font-mono leading-relaxed text-black/60 bg-black/5 p-2.5 overflow-x-auto"><code>extract(
-    schema=Invoice,
-    model=<span class="text-emerald-600">"xai:grok-4.3"</span>,
-    input_file=pdf_bytes,
-    media_type=<span class="text-emerald-600">"application/pdf"</span>,
-)</code></pre>
-            </div>
-
-            <div class="p-5 border border-black/10 bg-white">
-              <div class="flex items-center gap-3 mb-3">
-                <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
-                  <i data-lucide="refresh-cw" class="w-4 h-4 text-black/50"></i>
-                </div>
-                <span class="font-mono text-[10px] text-black/30 uppercase tracking-wider">Reliability</span>
-              </div>
-              <h3 class="font-mono text-sm font-medium text-black/80 mb-2">Retry with backoff</h3>
-              <p class="text-sm text-black/40 leading-relaxed mb-3">
-                Opt-in retries on <code class="font-mono text-black/60 text-xs">ModelError</code> with jittered exponential backoff.
-              </p>
-              <pre class="text-[11px] font-mono leading-relaxed text-black/60 bg-black/5 p-2.5 overflow-x-auto"><code>extract(
-    schema=Invoice,
-    model=<span class="text-emerald-600">"xai:grok-4.3"</span>,
-    input_file=path,
-    max_retries=<span class="text-emerald-600">3</span>,
-)</code></pre>
-            </div>
-
-            <div class="p-5 border border-black/10 bg-white">
-              <div class="flex items-center gap-3 mb-3">
-                <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
-                  <i data-lucide="activity" class="w-4 h-4 text-black/50"></i>
-                </div>
-                <span class="font-mono text-[10px] text-black/30 uppercase tracking-wider">Observability</span>
-              </div>
-              <h3 class="font-mono text-sm font-medium text-black/80 mb-2">Token usage</h3>
-              <p class="text-sm text-black/40 leading-relaxed mb-3">
-                <code class="font-mono text-black/60 text-xs">extract_with_usage</code> returns input, output, and total token counts.
-              </p>
-              <pre class="text-[11px] font-mono leading-relaxed text-black/60 bg-black/5 p-2.5 overflow-x-auto"><code>output, usage = extract_with_usage(
-    schema=Invoice,
-    model=<span class="text-emerald-600">"xai:grok-4.3"</span>,
-    input_file=path,
-)
-<span class="text-black/40">print(usage.total_tokens)</span></code></pre>
-            </div>
-
-            <div class="p-5 border border-black/10 bg-white">
-              <div class="flex items-center gap-3 mb-3">
-                <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
-                  <i data-lucide="layers" class="w-4 h-4 text-black/50"></i>
-                </div>
-                <span class="font-mono text-[10px] text-black/30 uppercase tracking-wider">Providers</span>
-              </div>
-              <h3 class="font-mono text-sm font-medium text-black/80 mb-2">11 providers</h3>
-              <p class="text-sm text-black/40 leading-relaxed mb-3">
-                OpenAI, Anthropic, Google, Bedrock, xAI, Cohere, Groq, Mistral, OpenRouter, Ollama, and more via one model string.
-              </p>
-            </div>
-
-            <div class="p-5 border border-black/10 bg-white">
-              <div class="flex items-center gap-3 mb-3">
-                <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
-                  <i data-lucide="shield-alert" class="w-4 h-4 text-black/50"></i>
-                </div>
-                <span class="font-mono text-[10px] text-black/30 uppercase tracking-wider">Errors</span>
-              </div>
-              <h3 class="font-mono text-sm font-medium text-black/80 mb-2">Typed classifier</h3>
-              <p class="text-sm text-black/40 leading-relaxed mb-3">
-                Native provider errors become <code class="font-mono text-black/60 text-xs">ModelError</code> by type, not substring matching.
-              </p>
-              <pre class="text-[11px] font-mono leading-relaxed text-black/60 bg-black/5 p-2.5 overflow-x-auto"><code><span class="text-black/40">try:</span>
-    extract(...)
-<span class="text-black/40">except</span> ModelError:
-    <span class="text-black/40">...  # provider issue</span>
-<span class="text-black/40">except</span> SchemaValidationError:
-    <span class="text-black/40">...  # bad shape</span></code></pre>
             </div>
 
           </div>
@@ -412,34 +204,34 @@
           <div class="grid grid-cols-1 lg:grid-cols-[1fr,1.4fr] gap-8 lg:gap-12 items-center">
 
             <div>
-              <p class="font-mono text-[11px] text-black/30 uppercase tracking-wider mb-3">How it works</p>
+              <p class="font-mono text-[11px] text-black/40 uppercase tracking-wider mb-3">How it works</p>
               <h2 class="text-2xl sm:text-3xl font-bold mb-4 sm:mb-6 text-black/90">
                 Schema in, typed data out
               </h2>
-              <p class="text-black/40 mb-8 leading-relaxed">
-                Define a <code class="font-mono text-black/70 bg-black/5 px-1.5 py-0.5 text-sm">BaseModel</code>, call <code class="font-mono text-black/70 bg-black/5 px-1.5 py-0.5 text-sm">extract()</code>, get validated output.
+              <p class="text-black/60 mb-8 leading-relaxed">
+                Define a <code class="font-mono text-black/90 bg-black/5 px-1.5 py-0.5 text-sm">BaseModel</code>, call <code class="font-mono text-black/90 bg-black/5 px-1.5 py-0.5 text-sm">extract()</code>, get validated output.
               </p>
 
               <div class="space-y-5">
                 <div class="flex gap-4">
                   <div class="w-7 h-7 border border-black/10 flex items-center justify-center font-mono text-xs text-black/40 flex-shrink-0">1</div>
                   <div>
-                    <h4 class="font-mono text-sm text-black/70 mb-1">Define a schema</h4>
-                    <p class="text-sm text-black/40">Describe the shape you want with a Pydantic model.</p>
+                    <h4 class="font-mono text-sm text-black/90 mb-1">Define a schema</h4>
+                    <p class="text-sm text-black/60">Describe the shape you want with a Pydantic model.</p>
                   </div>
                 </div>
                 <div class="flex gap-4">
                   <div class="w-7 h-7 border border-black/10 flex items-center justify-center font-mono text-xs text-black/40 flex-shrink-0">2</div>
                   <div>
-                    <h4 class="font-mono text-sm text-black/70 mb-1">Point at any media</h4>
-                    <p class="text-sm text-black/40">Documents, images, audio, or video via URL.</p>
+                    <h4 class="font-mono text-sm text-black/90 mb-1">Point at any media</h4>
+                    <p class="text-sm text-black/60">Documents, images, audio, or video via URL.</p>
                   </div>
                 </div>
                 <div class="flex gap-4">
                   <div class="w-7 h-7 border border-black/10 flex items-center justify-center font-mono text-xs text-black/40 flex-shrink-0">3</div>
                   <div>
-                    <h4 class="font-mono text-sm text-black/70 mb-1">Get typed output</h4>
-                    <p class="text-sm text-black/40">Validated against your schema. No parsing, no regex.</p>
+                    <h4 class="font-mono text-sm text-black/90 mb-1">Get typed output</h4>
+                    <p class="text-sm text-black/60">Validated against your schema. No parsing, no regex.</p>
                   </div>
                 </div>
               </div>
@@ -447,8 +239,8 @@
 
             <div class="code-block overflow-hidden">
               <div class="px-3 sm:px-4 py-2.5 border-b border-black/5 flex items-center justify-between">
-                <span class="font-mono text-[10px] text-black/30 uppercase tracking-wider">Terminal</span>
-                <span class="font-mono text-[10px] text-black/20">extract.py</span>
+                <span class="font-mono text-[10px] text-black/40 uppercase tracking-wider">Terminal</span>
+                <span class="font-mono text-[10px] text-black/40">extract.py</span>
               </div>
               <div class="p-3 sm:p-4 overflow-x-auto">
 <pre class="text-xs sm:text-sm font-mono leading-relaxed"><code><span class="text-black/40">from</span> <span class="text-black/70">pydantic</span> <span class="text-black/40">import</span> <span class="text-black/70">BaseModel</span>
@@ -472,25 +264,62 @@
         </div>
       </section>
 
+      <!-- What's new in 0.8.0 -->
+      <section id="whats-new" class="py-16 sm:py-24 border-t border-black/5 scroll-mt-14">
+        <div class="max-w-5xl mx-auto px-4 sm:px-6">
+          <div class="flex items-baseline justify-between mb-8 sm:mb-10 flex-wrap gap-3">
+            <div>
+              <p class="font-mono text-[11px] text-black/40 uppercase tracking-wider mb-2">What&rsquo;s new</p>
+              <h2 class="text-2xl sm:text-3xl font-bold text-black/90">v0.8.0</h2>
+            </div>
+            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/CHANGELOG.md#080---2026-06-02" class="font-mono text-xs text-black/40 hover:text-black/90 transition-colors inline-flex items-center gap-1.5">
+              Full changelog <i data-lucide="arrow-up-right" class="w-3 h-3"></i>
+            </a>
+          </div>
+
+          <div class="p-6 border border-black/10 bg-white">
+            <div class="flex items-center gap-3 mb-3">
+              <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
+                <i data-lucide="package" class="w-4 h-4 text-black/40"></i>
+              </div>
+              <span class="font-mono text-[10px] text-black/40 uppercase tracking-wider">v0.8.0 &middot; Install</span>
+            </div>
+            <h3 class="font-mono text-base font-medium text-black/90 mb-2">Slim core, optional provider extras</h3>
+            <p class="text-sm text-black/60 leading-relaxed mb-4">
+              <code class="font-mono text-black/90 text-xs">pip install openextract</code> and <code class="font-mono text-black/90 text-xs">uv add openextract</code> ship a lean dependency set. Add the SDK you need for model calls &mdash; for example <code class="font-mono text-black/90 text-xs">openextract[openai]</code> or <code class="font-mono text-black/90 text-xs">openextract[all]</code>.
+            </p>
+            <div class="flex flex-wrap gap-1.5">
+              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">[openai]</span>
+              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">[anthropic]</span>
+              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">[google]</span>
+              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">[bedrock]</span>
+              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">[groq]</span>
+              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">[mistral]</span>
+              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">[all]</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <!-- Supported Formats -->
       <section class="py-16 sm:py-24 border-t border-black/5">
         <div class="max-w-3xl mx-auto px-4 sm:px-6 text-center">
-          <h2 class="font-mono text-sm text-black/50 mb-6">Works with any media</h2>
+          <h2 class="font-mono text-sm text-black/60 mb-6">Works with any media</h2>
           <div class="flex flex-wrap justify-center gap-2">
-            <span class="inline-flex items-center gap-2 text-sm text-black/50 border border-black/10 bg-white px-4 py-2">
+            <span class="inline-flex items-center gap-2 text-sm text-black/60 border border-black/10 bg-white px-4 py-2">
               <i data-lucide="file-text" class="w-4 h-4"></i> Documents
             </span>
-            <span class="inline-flex items-center gap-2 text-sm text-black/50 border border-black/10 bg-white px-4 py-2">
+            <span class="inline-flex items-center gap-2 text-sm text-black/60 border border-black/10 bg-white px-4 py-2">
               <i data-lucide="image" class="w-4 h-4"></i> Images
             </span>
-            <span class="inline-flex items-center gap-2 text-sm text-black/50 border border-black/10 bg-white px-4 py-2">
+            <span class="inline-flex items-center gap-2 text-sm text-black/60 border border-black/10 bg-white px-4 py-2">
               <i data-lucide="volume-2" class="w-4 h-4"></i> Audio
             </span>
-            <span class="inline-flex items-center gap-2 text-sm text-black/50 border border-black/10 bg-white px-4 py-2">
+            <span class="inline-flex items-center gap-2 text-sm text-black/60 border border-black/10 bg-white px-4 py-2">
               <i data-lucide="video" class="w-4 h-4"></i> Video
             </span>
           </div>
-          <p class="font-mono text-xs text-black/30 mt-5">PDF, DOCX, PNG, JPG, MP3, MP4, and 20+ formats</p>
+          <p class="font-mono text-xs text-black/40 mt-5">PDF, DOCX, PNG, JPG, MP3, MP4, and 20+ formats</p>
         </div>
       </section>
 
@@ -499,10 +328,10 @@
     <!-- Footer -->
     <footer class="py-6 sm:py-8 border-t border-black/5">
       <div class="max-w-5xl mx-auto px-4 sm:px-6 flex flex-col sm:flex-row justify-between items-center gap-4">
-        <span class="font-mono text-xs text-black/30">&copy; 2026 openextract. MIT License.</span>
+        <span class="font-mono text-xs text-black/40">&copy; 2026 openextract. MIT License.</span>
         <div class="flex gap-6">
-          <a href="https://github.com/Mellow-Artificial-Intelligence/openextract" class="font-mono text-xs text-black/30 hover:text-black/60 transition-colors">GitHub</a>
-          <a href="https://pypi.org/project/openextract/" class="font-mono text-xs text-black/30 hover:text-black/60 transition-colors">PyPI</a>
+          <a href="https://github.com/Mellow-Artificial-Intelligence/openextract" class="font-mono text-xs text-black/40 hover:text-black/60 transition-colors">GitHub</a>
+          <a href="https://pypi.org/project/openextract/" class="font-mono text-xs text-black/40 hover:text-black/60 transition-colors">PyPI</a>
         </div>
       </div>
     </footer>
@@ -533,17 +362,6 @@
           setTimeout(() => {
             document.getElementById('check-icon').classList.add('hidden');
             document.getElementById('copy-icon').classList.remove('hidden');
-          }, 1500);
-        });
-      }
-
-      function copyInstallBasic() {
-        copyToClipboard("uv add openextract").then(() => {
-          document.getElementById('copy-icon-basic').classList.add('hidden');
-          document.getElementById('check-icon-basic').classList.remove('hidden');
-          setTimeout(() => {
-            document.getElementById('check-icon-basic').classList.add('hidden');
-            document.getElementById('copy-icon-basic').classList.remove('hidden');
           }, 1500);
         });
       }


### PR DESCRIPTION
## Summary

Tighten and de-clutter the landing page in `docs/index.html`: fewer repeated cards, one reveal animation, a consolidated grey scale, and a fuller hero.

## Changes

- Trim the What\'s new section from 10 cards to one highlight (slim core / optional extras) plus a changelog link
- Remove staggered `animate-slide-up` animations outside the hero badge + headline so content shows immediately
- Consolidate the grey scale to three values: `/90` headings, `/60` body, `/40` muted/captions
- Drop the duplicate hero code block; the How it works section carries the single Python demo
- Remove the `hero-glow` ambient effect so the grid background is the sole texture
- Add a compact terminal preview (install + CLI run + JSON output) to the hero to fill it out
- Tighten the top padding above the features grid to remove the double gap below the hero
- Remove the dead `copyInstallBasic` function (referenced elements that no longer exist)

## Testing

- Visual only — no Python or test changes. Previewed locally via `npx live-server docs` with hot reload.

## Checklist

- [ ] Tests pass locally (`uv run pytest`)
- [ ] Linting passes (`uv run ruff check .`)
- [x] Documentation updated (if applicable)