### PR TITLE
docs: document bench.py as a maintainer tool

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,16 @@ A scheduled GitHub Actions workflow (`.github/workflows/embargo-bump.yml`) runs 
 
 If you need to add a dependency that was published in the last 24 hours, hold off and wait the embargo out rather than bumping `exclude-newer` past the rolling window.
 
+## Performance benchmarking (maintainers)
+
+`scripts/bench.py` microbenchmarks openextract's local hot path — import cost, media loading, agent construction, and mocked extraction. Run it on the same machine before and after performance-sensitive changes:
+
+```bash
+uv run python scripts/bench.py
+```
+
+It deliberately does **not** measure model or network latency. See [docs/benchmarking.md](docs/benchmarking.md) for what it measures, when to run it, and how to read the output without overfitting to local noise.
+
 ## Questions?
 
 Open an issue on GitHub.

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,0 +1,84 @@
+---
+layout: page
+title: Benchmarking
+---
+
+# Benchmarking (maintainer tool)
+
+`scripts/bench.py` is a maintainer-facing microbenchmark for openextract's
+**local** hot path — the CPU work that runs around every extraction call. It
+exists to catch local performance regressions during development. It is **not**
+a published performance benchmark, and its numbers are not portable across
+machines.
+
+## How to run
+
+From the repository root, with the [uv](https://docs.astral.sh/uv/)
+environment set up (`uv sync --dev`):
+
+```bash
+uv run python scripts/bench.py
+```
+
+It needs no API keys and makes no network calls — it stubs dummy provider
+credentials and mocks the LLM call. Results are printed to stdout and the
+script exits `0`.
+
+## What it measures
+
+Most rows report `median`, `p95`, and `best` over `n` iterations (after a
+warmup), so both typical and tail cost are visible. The `[import]` row instead
+reports `median`, `best`, and `worst` over a fixed 5 runs:
+
+- **`[import]`** — cold-start cost of `import openextract`, measured in a fresh
+  subprocess (5 runs).
+- **`[_get_media]`** — resolving an `input_file` to `(bytes, media_type)` for a
+  small text file, a ~50 KB PDF, a ~5 MB PDF, and raw `bytes` input.
+- **`[_get_media_type]`** — `mimetypes.guess_type` on a filename.
+- **`[dotenv]`** — per-call cost of `load_dotenv()` (invoked inside every
+  extract).
+- **`[_build_agent]`** — constructing a `pydantic_ai.Agent` for a non-Ollama
+  and an Ollama model.
+- **`[extract]` / `[extract_many]`** — the full `extract()` / `extract_many()`
+  path with the `Agent` **mocked out**: all per-call local cost (dotenv + media
+  read + agent build + dispatch) *except* the model call.
+
+## What it intentionally does NOT measure
+
+- **Model / network / inference latency.** The LLM round-trip is mocked. In
+  real usage it dominates total time by orders of magnitude; this tool
+  deliberately excludes it so the local CPU costs are visible at all.
+- **Provider SDK network calls**, rate limits, retries, or token costs.
+- **Cross-machine or absolute performance.** Numbers reflect the specific
+  machine, Python build, and system load at the moment of the run.
+
+## When maintainers should run it
+
+Run it **before and after** a change that touches the local hot path, and
+compare the two runs on the **same machine**:
+
+- changes to `import openextract` or module-level import work,
+- `_get_media` / media handling,
+- `_build_agent` / agent construction,
+- the per-call `load_dotenv()` behavior,
+- `extract` / `extract_many` dispatch and concurrency.
+
+It is also useful when investigating a reported startup or import-time
+regression.
+
+## How to interpret the output
+
+- **Compare deltas, not absolutes.** Treat the numbers as a relative baseline
+  for *your* machine. A meaningful result is a consistent before/after
+  difference on the same hardware — not a particular millisecond value.
+- **Prefer `median`; watch `p95`.** The median is the stable signal; `p95` and
+  `worst` show tail behavior and are noisier.
+- **Reduce noise.** Close other heavy processes, keep laptops on AC power (they
+  throttle on battery), and run a couple of times — the first `import` and
+  agent-build runs are often slower.
+- **Don't compare across machines or against CI.** Different CPUs, Python
+  builds, and background load make absolute numbers incomparable.
+
+> These measurements are a local diagnostic aid. They are **not** universal
+> performance guarantees and should not be quoted as openextract's performance
+> characteristics.

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -21,7 +21,10 @@ from unittest.mock import MagicMock, patch
 from pydantic import BaseModel
 
 # Stub credentials so pydantic-ai provider clients can be instantiated locally.
+# These are never used for real calls: the extract benchmarks mock the Agent,
+# and the agent-construction benchmark only needs the provider to initialize.
 os.environ.setdefault("OPENAI_API_KEY", "sk-bench-dummy")
+os.environ.setdefault("XAI_API_KEY", "xai-bench-dummy")
 os.environ.setdefault("OLLAMA_BASE_URL", "http://localhost:11434/v1")
 
 


### PR DESCRIPTION
Closes #128.

## What

Adds maintainer-facing documentation for `scripts/bench.py`, per the roadmap's [Performance baselines](https://github.com/Mellow-Artificial-Intelligence/openextract/wiki/Roadmap#5-performance-baselines) item.

- **`docs/benchmarking.md`** (new) — how to run it with the current `uv` setup, what it measures (import cost, `_get_media`, `_get_media_type`, `load_dotenv`, `_build_agent`, mocked `extract`/`extract_many`), what it **intentionally does not measure** (model/network/inference latency — the LLM call is mocked), when maintainers should run it, and how to interpret the output without overfitting to local-machine noise.
- **`CONTRIBUTING.md`** — a short "Performance benchmarking (maintainers)" section pointing to the new doc.

## Small bug fix (allowed by the acceptance criteria)

While verifying the documented command, I found the script **could not run to completion**: `bench_build_agent` constructs a real `pydantic_ai.Agent("xai:grok-4.3")`, which requires `XAI_API_KEY`, but only `OPENAI_API_KEY` and `OLLAMA_BASE_URL` were stubbed — so it crashed with `UserError: Set the XAI_API_KEY environment variable...`.

Fix is one line: stub a dummy `XAI_API_KEY` alongside the others. The dummy value is never used for a real call (the `extract`/`extract_many` benches mock the `Agent`; agent construction only needs the provider to initialize). This is the "small bug" the issue's acceptance criteria explicitly anticipate, and it's required for the documented command to work.

## Verification

The documented command now runs end to end (no API keys, no network):

```
$ uv run python scripts/bench.py
[import] cold-start cost of `import openextract` (subprocess)
  median= 341.037 ms  best= 337.860 ms  worst= 357.842 ms
[_get_media] ...
[_build_agent] constructing a pydantic_ai.Agent
  _build_agent(non-ollama)                   median=  157.98 us  ...
  _build_agent(ollama)                       median=   3.501 ms  ...
[extract] sync extract() with Agent mocked (all-local cost per call)
  extract(path, xai:grok-4.3)                median=   54.83 us  ...
[extract_many] 20 inputs, max_concurrency=5, Agent mocked
  extract_many(20 files, conc=5)             median=   1.022 ms  ...
```

- `uv run ruff check scripts/bench.py` — clean
- `uv run ruff format --check scripts/bench.py` — clean

## Acceptance criteria

- [x] Documentation added in a maintainer-facing location (`docs/benchmarking.md` + `CONTRIBUTING.md` pointer)
- [x] The documented command works with the current `uv` setup
- [x] Docs avoid presenting benchmark numbers as universal performance guarantees (explicit caveat)
- [x] No benchmark behavior changes beyond the one small bug fix needed to run it

(Example numbers above are from one local machine and are illustrative only — not performance guarantees, as the docs note.)