### PR TITLE
docs: link the roadmap wiki from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,10 @@ CI runs the test suite on every PR and fails if total coverage drops below 100%.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor guide.
 
+## Roadmap
+
+The project roadmap lives in the [GitHub Wiki](https://github.com/Mellow-Artificial-Intelligence/openextract/wiki/Roadmap).
+
 ## License
 
 [MIT](LICENSE) &copy; Cole McIntosh


### PR DESCRIPTION
Closes #121.

The detailed roadmap now lives in the [GitHub Wiki](https://github.com/Mellow-Artificial-Intelligence/openextract/wiki/Roadmap), but nothing in the repository pointed to it. This adds a short, clearly-labelled `## Roadmap` section to the README so a new visitor can find it from the main entry point.

## Acceptance criteria

- [x] A new visitor can find the roadmap from the repository README
- [x] The link points to the GitHub Wiki roadmap page (not a removed in-repo file)
- [x] No unrelated README or docs rewrites included (single section added)
- [x] Formatting consistent with the surrounding `##` sections