### PR TITLE
[codex] Validate retry and concurrency options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ timing when that is known.
 - README public API stability audit covering every symbol exported from
   `openextract.__all__`, plus CLI stability notes and pre-1.0 follow-ups.
 
+### Changed
+- `max_retries`, `retry_backoff`, and `max_concurrency` now fail early with
+  deterministic `ValueError` messages when invalid values are provided.
+
 ## [0.8.0] - 2026-06-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ result = extract(
 )
 ```
 
-`max_retries` defaults to `0` (single attempt). When set, `extract` retries only on `ModelError` and sleeps `retry_backoff * (2 ** attempt)` seconds (with up to 25% jitter) between attempts. `retry_backoff` defaults to `1.0` second.
+`max_retries` defaults to `0` (single attempt) and must be a non-negative integer. When set, `extract` retries only on `ModelError` and sleeps `retry_backoff * (2 ** attempt)` seconds (with up to 25% jitter) between attempts. `retry_backoff` defaults to `1.0` second and must be positive and finite.
 
 ### Inspecting token usage
 
@@ -258,8 +258,8 @@ All `openextract` exceptions inherit from `ExtractionError`, so you can catch it
 | `input_file`    | `str \| bytes \| BinaryIO`    | A local file path, an `https://` URL, raw `bytes`, or a binary file-like object with a `.read()` method.          |
 | `instructions`  | `str \| None`                 | Optional natural-language guidance for the model.                                                                 |
 | `media_type`    | `str \| None` (keyword-only)  | MIME type. Required for `bytes` and file-like inputs; overrides the guessed type for `str` inputs when provided.  |
-| `max_retries`   | `int` (keyword-only)          | Extra attempts after a `ModelError`. Defaults to `0` (no retry).                                                  |
-| `retry_backoff` | `float` (keyword-only)        | Base seconds for exponential backoff with jitter between retries.                                                 |
+| `max_retries`   | `int` (keyword-only)          | Extra attempts after a `ModelError`. Must be a non-negative integer. Defaults to `0` (no retry).                 |
+| `retry_backoff` | `float` (keyword-only)        | Base seconds for exponential backoff with jitter between retries. Must be positive and finite.                   |
 
 Returns an instance of `schema`.
 
@@ -285,10 +285,10 @@ Run concurrent extractions from synchronous code. Each item in `input_files` is 
 | -------------------- | ---------------------------- | --------------------------------------------------------------------------- |
 | `input_files`        | `Iterable[str \| bytes \| BinaryIO]` | One input per extraction.                                          |
 | `media_type`         | `str \| None` (keyword-only) | Applied uniformly to every item; required if any item is `bytes`/file-like. |
-| `max_concurrency`    | `int` (keyword-only)         | Maximum in-flight extractions (default `5`).                                |
+| `max_concurrency`    | `int` (keyword-only)         | Maximum in-flight extractions. Must be a positive integer. Defaults to `5`. |
 | `return_exceptions`  | `bool` (keyword-only)        | If `True`, exceptions appear in the result list instead of being raised.    |
-| `max_retries`        | `int` (keyword-only)         | Per-item extra attempts after a `ModelError`. Defaults to `0`.              |
-| `retry_backoff`      | `float` (keyword-only)       | Base seconds for per-item exponential backoff with jitter.                  |
+| `max_retries`        | `int` (keyword-only)         | Per-item extra attempts after a `ModelError`. Must be a non-negative integer. Defaults to `0`. |
+| `retry_backoff`      | `float` (keyword-only)       | Base seconds for per-item exponential backoff with jitter. Must be positive and finite. |
 
 Returns a `list` of schema instances (or exceptions when `return_exceptions=True`).
 
@@ -319,8 +319,8 @@ the compatibility notes below even though it is not exported from `__all__`.
 | `extract_async` | Stable | Async sibling of `extract`; same input contract and retry behavior, with `Agent.run` instead of `run_sync`. |
 | `extract_with_usage` | Stable | Usage-returning sync API. The `(output, Usage)` tuple shape is stable; exact token values depend on provider reporting. |
 | `extract_with_usage_async` | Stable | Async sibling of `extract_with_usage`; same tuple shape and retry behavior. |
-| `extract_many` | Provisional | Batch return ordering and `return_exceptions` semantics are intended to remain, but pre-1.0 work should validate retry/concurrency options and clarify behavior when called inside an active event loop. |
-| `extract_many_async` | Provisional | Async batch API with the same return shape as `extract_many`; pre-1.0 work should validate retry/concurrency options. |
+| `extract_many` | Provisional | Batch return ordering, option validation, and `return_exceptions` semantics are intended to remain, but pre-1.0 work should clarify behavior when called inside an active event loop. |
+| `extract_many_async` | Provisional | Async batch API with the same return shape, option constraints, and per-item retry behavior as `extract_many`. |
 | `Usage` | Stable | Frozen dataclass with `input_tokens`, `output_tokens`, and `total_tokens`. New fields, if ever needed, should be additive. |
 | `ExtractionError` | Stable | Base class for all public `openextract` exceptions. Catch this for a broad fallback. |
 | `UrlFetchError` | Stable | Raised for URL fetch and URL safety failures. Message wording may improve, but the exception type is stable. |
@@ -330,8 +330,7 @@ the compatibility notes below even though it is not exported from `__all__`.
 | `openextract` CLI | Provisional | The command, core flags, JSON output, and documented exit-code categories are intended to remain, but provider-install and partial-batch failure behavior should finish release validation before 0.9. |
 
 No pre-1.0 signature changes are currently proposed for stable symbols. Known
-pre-1.0 follow-ups are limited to validation and documentation around batch
-concurrency, retry option constraints, active-event-loop behavior, and final CLI
+pre-1.0 follow-ups are limited to active-event-loop behavior and final CLI
 release readiness.
 
 ## Compatibility and deprecation policy

--- a/src/openextract/_cli.py
+++ b/src/openextract/_cli.py
@@ -244,6 +244,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     except ExtractionError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 5
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
 
     if args.output == "repr":
         _print_json(payload, as_repr=True)

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -3,6 +3,7 @@
 import asyncio
 import importlib
 import ipaddress
+import math
 import mimetypes
 import os
 import random
@@ -413,6 +414,27 @@ def _retry_delay(retry_backoff: float, attempt: int) -> float:
     return retry_backoff * (2**attempt) * (1 + random.uniform(0, 0.25))
 
 
+def _validate_retry_options(max_retries: object, retry_backoff: object) -> None:
+    if isinstance(max_retries, bool) or not isinstance(max_retries, int) or max_retries < 0:
+        raise ValueError("max_retries must be a non-negative integer.")
+    if (
+        isinstance(retry_backoff, bool)
+        or not isinstance(retry_backoff, int | float)
+        or not math.isfinite(retry_backoff)
+        or retry_backoff <= 0
+    ):
+        raise ValueError("retry_backoff must be a finite positive number of seconds.")
+
+
+def _validate_max_concurrency(max_concurrency: object) -> None:
+    if (
+        isinstance(max_concurrency, bool)
+        or not isinstance(max_concurrency, int)
+        or max_concurrency < 1
+    ):
+        raise ValueError("max_concurrency must be a positive integer.")
+
+
 def _run_with_retries_sync[R](
     fn: Callable[[], R],
     *,
@@ -420,6 +442,7 @@ def _run_with_retries_sync[R](
     retry_backoff: float,
 ) -> R:
     """Run ``fn`` until it succeeds or ``ModelError`` retries are exhausted."""
+    _validate_retry_options(max_retries, retry_backoff)
     attempt = 0
     while True:
         try:
@@ -438,6 +461,7 @@ async def _run_with_retries_async[R](
     retry_backoff: float,
 ) -> R:
     """Async counterpart to :func:`_run_with_retries_sync`."""
+    _validate_retry_options(max_retries, retry_backoff)
     attempt = 0
     while True:
         try:
@@ -596,6 +620,8 @@ async def _gather_extractions(
     max_retries: int,
     retry_backoff: float,
 ) -> list:
+    _validate_retry_options(max_retries, retry_backoff)
+    _validate_max_concurrency(max_concurrency)
     files = list(input_files)
     if not files:
         return []
@@ -652,7 +678,13 @@ def extract_many(
 
     Returns:
         A list of results (or exceptions, when ``return_exceptions=True``) in input order.
+
+    Raises:
+        ValueError: If ``max_concurrency`` is less than 1, ``max_retries`` is
+            negative, or ``retry_backoff`` is not positive and finite.
     """
+    _validate_retry_options(max_retries, retry_backoff)
+    _validate_max_concurrency(max_concurrency)
     return asyncio.run(
         _gather_extractions(
             schema,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -245,6 +245,38 @@ class TestMainSuccess:
         assert mock_extract.call_args.kwargs["max_retries"] == 3
         assert mock_extract.call_args.kwargs["retry_backoff"] == 2.5
 
+    def test_invalid_max_retries_returns_1(self, capsys):
+        exit_code = main(
+            [
+                "input.txt",
+                "--schema",
+                "tests.test_cli:_FixtureSchema",
+                "--model",
+                "xai:grok-4.3",
+                "--max-retries",
+                "-1",
+            ]
+        )
+
+        assert exit_code == 1
+        assert "max_retries" in capsys.readouterr().err
+
+    def test_invalid_retry_backoff_returns_1(self, capsys):
+        exit_code = main(
+            [
+                "input.txt",
+                "--schema",
+                "tests.test_cli:_FixtureSchema",
+                "--model",
+                "xai:grok-4.3",
+                "--retry-backoff",
+                "0",
+            ]
+        )
+
+        assert exit_code == 1
+        assert "retry_backoff" in capsys.readouterr().err
+
 
 # ---------------------------------------------------------------------------
 # main error paths / exit codes

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -913,6 +913,33 @@ class TestExtractWithUsage:
 
 
 class TestExtractRetry:
+    def test_invalid_max_retries_is_rejected_before_extraction(self, mocker):
+        once = mocker.patch("openextract._extract._extract_once")
+
+        with pytest.raises(ValueError, match="max_retries"):
+            extract(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_file="ignored",
+                max_retries=-1,
+            )
+
+        once.assert_not_called()
+
+    @pytest.mark.parametrize("retry_backoff", [0, -1.0, float("inf"), "slow", True])
+    def test_invalid_retry_backoff_is_rejected_before_extraction(self, mocker, retry_backoff):
+        once = mocker.patch("openextract._extract._extract_once")
+
+        with pytest.raises(ValueError, match="retry_backoff"):
+            extract(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_file="ignored",
+                retry_backoff=retry_backoff,  # type: ignore[arg-type]
+            )
+
+        once.assert_not_called()
+
     def test_no_retry_by_default_raises_immediately(self, mocker):
         sleep_mock = mocker.patch("openextract._extract.time.sleep")
         once = mocker.patch(
@@ -1006,6 +1033,19 @@ class TestExtractRetry:
 
 
 class TestExtractWithUsageRetry:
+    def test_invalid_retry_options_are_rejected_before_extraction(self, mocker):
+        run_extraction = mocker.patch("openextract._extract._run_extraction")
+
+        with pytest.raises(ValueError, match="max_retries"):
+            extract_with_usage(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_file="ignored",
+                max_retries=True,  # type: ignore[arg-type]
+            )
+
+        run_extraction.assert_not_called()
+
     def test_retries_on_model_error(self, mocker):
         sleep_mock = mocker.patch("openextract._extract.time.sleep")
         expected = _Person(name="Ada", age=36)
@@ -1031,6 +1071,19 @@ class TestExtractWithUsageRetry:
 
 
 class TestExtractAsyncRetry:
+    async def test_invalid_retry_options_are_rejected_before_agent_build(self, mocker):
+        agent_cls = mocker.patch("openextract._extract.Agent")
+
+        with pytest.raises(ValueError, match="retry_backoff"):
+            await extract_async(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_file="ignored",
+                retry_backoff=0,
+            )
+
+        agent_cls.assert_not_called()
+
     async def test_retries_on_model_error(self, tmp_path, mocker):
         local = tmp_path / "input.txt"
         local.write_bytes(b"hi")
@@ -1186,6 +1239,19 @@ class TestExtractAsync:
 
 
 class TestExtractWithUsageAsync:
+    async def test_invalid_retry_options_are_rejected_before_agent_build(self, mocker):
+        agent_cls = mocker.patch("openextract._extract.Agent")
+
+        with pytest.raises(ValueError, match="max_retries"):
+            await extract_with_usage_async(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_file="ignored",
+                max_retries=-1,
+            )
+
+        agent_cls.assert_not_called()
+
     async def test_returns_output_and_usage_tuple(self, tmp_path, mocker):
         local = tmp_path / "input.txt"
         local.write_bytes(b"hello")
@@ -1308,6 +1374,32 @@ def _stub_shared_agent(mocker, side_effect):
 
 
 class TestExtractMany:
+    def test_invalid_max_concurrency_is_rejected_before_agent_build(self, mocker):
+        build_mock = mocker.patch("openextract._extract._build_agent")
+
+        with pytest.raises(ValueError, match="max_concurrency"):
+            extract_many(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_files=["a.txt"],
+                max_concurrency=0,
+            )
+
+        build_mock.assert_not_called()
+
+    def test_invalid_retry_options_are_rejected_before_agent_build(self, mocker):
+        build_mock = mocker.patch("openextract._extract._build_agent")
+
+        with pytest.raises(ValueError, match="max_retries"):
+            extract_many(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_files=["a.txt"],
+                max_retries=-1,
+            )
+
+        build_mock.assert_not_called()
+
     def test_preserves_input_order(self, tmp_path, mocker):
         files = []
         for i in range(4):
@@ -1448,6 +1540,19 @@ class TestExtractMany:
 
 
 class TestExtractManyAsync:
+    async def test_invalid_options_are_rejected_before_agent_build(self, mocker):
+        build_mock = mocker.patch("openextract._extract._build_agent")
+
+        with pytest.raises(ValueError, match="max_concurrency"):
+            await extract_many_async(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_files=["a.txt"],
+                max_concurrency=False,  # type: ignore[arg-type]
+            )
+
+        build_mock.assert_not_called()
+
     async def test_fail_fast_propagates_first_error(self, tmp_path, mocker):
         files = [str(tmp_path / f"f{i}.txt") for i in range(3)]
 


### PR DESCRIPTION
## Summary
- Validate `max_retries`, `retry_backoff`, and `max_concurrency` before extraction work starts.
- Return a normal CLI error for invalid retry options instead of leaking a traceback.
- Document accepted option ranges and update the changelog/API stability notes.

Closes #117

## Checks
- `uv run pytest tests/test_extract.py tests/test_cli.py -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest -q`