### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ timing when that is known.
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-12
+
 ### Added
 - Compatibility and deprecation policy documenting the public API surface,
   pre-1.0 breaking-change expectations, provider compatibility limits, and
@@ -119,7 +121,8 @@ timing when that is known.
 ## [0.1.1] - 2025-09-10
 - Merge pull request #12 from Mellow-Artificial-Intelligence/new-release.
 
-[Unreleased]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.5.0...v0.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openextract"
-version = "0.8.0"
+version = "0.9.0"
 description = "Extract structured data from documents, images, audio, and video using LLMs"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1229,7 +1229,7 @@ wheels = [
 
 [[package]]
 name = "openextract"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Prepare the OpenExtract `v0.9.0` release.

## Changes

- Bump package version from `0.8.0` to `0.9.0` in `pyproject.toml` and `uv.lock`.
- Move existing `[Unreleased]` changelog entries under `## [0.9.0] - 2026-07-12`.
- Refresh changelog comparison links for `[Unreleased]` and `[0.9.0]`.

## Testing

- `uv sync --dev`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest -v --cov=openextract --cov-report=term-missing --cov-fail-under=0`
- `uv run coverage report --fail-under=100`
- `uv build`

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Documentation updated (if applicable)
