### PR TITLE
docs: finish provider CLI release readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ timing when that is known.
   exit `7` if any input failed (default remains abort-on-first-failure).
 - README public API stability audit covering every symbol exported from
   `openextract.__all__`, plus CLI stability notes and pre-1.0 follow-ups.
+- Release-readiness documentation for provider install errors, extra-specific
+  install hints, and CLI partial-batch failure stdout/stderr and exit-code
+  behavior.
 
 ### Changed
 - `max_retries`, `retry_backoff`, and `max_concurrency` now fail early with

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Or with pip:
 pip install openextract
 ```
 
-Model calls require a provider SDK. Install the extra for the provider you use, for example `openextract[openai]`, `openextract[anthropic]`, or `openextract[all]` for every supported provider. The base package ships `pydantic-ai-slim` without provider SDKs pre-installed.
+Model calls require a provider SDK. Install the extra for the provider you use, for example `openextract[openai]`, `openextract[anthropic]`, or `openextract[all]` for every supported provider. The base package ships `pydantic-ai-slim` without provider SDKs pre-installed. If the requested provider SDK is missing, `openextract` raises `ProviderNotInstalledError` with a provider-specific `pip install 'openextract[...]'` command when the model prefix is known.
 
 Requires Python 3.12+.
 
@@ -127,21 +127,21 @@ print(f"tokens: {usage.input_tokens} in / {usage.output_tokens} out / {usage.tot
 
 `model` follows the `pydantic-ai` provider prefix convention:
 
-| Provider     | Example identifier                                       |
-| ------------ | -------------------------------------------------------- |
-| OpenAI       | `openai:gpt-5`                                           |
-| Anthropic    | `anthropic:claude-sonnet-4`                              |
-| Google       | `google-gla:gemini-2.5-pro`                              |
-| AWS Bedrock  | `bedrock:anthropic.claude-sonnet-4-20250514-v1:0`        |
-| xAI          | `xai:grok-4.3`                                             |
-| Cohere       | `cohere:command-r-plus`                                  |
-| Hugging Face | `huggingface:meta-llama/Llama-3.3-70B-Instruct`          |
-| Groq         | `groq:llama-3.3-70b-versatile`                           |
-| Cerebras     | `cerebras:llama3.1-70b`                                  |
-| Mistral      | `mistral:mistral-large-latest`                           |
-| OpenRouter   | `openrouter:anthropic/claude-sonnet-4`                   |
-| Outlines     | `outlines:transformers/meta-llama/Llama-3.2-1B-Instruct` |
-| Ollama       | `ollama:llama3`                                          |
+| Provider     | Example identifier                                       | Install extra |
+| ------------ | -------------------------------------------------------- | ------------- |
+| OpenAI       | `openai:gpt-5`                                           | `openextract[openai]` |
+| Anthropic    | `anthropic:claude-sonnet-4`                              | `openextract[anthropic]` |
+| Google       | `google-gla:gemini-2.5-pro`                              | `openextract[google]` |
+| AWS Bedrock  | `bedrock:anthropic.claude-sonnet-4-20250514-v1:0`        | `openextract[bedrock]` |
+| xAI          | `xai:grok-4.3`                                           | `openextract[xai]` |
+| Cohere       | `cohere:command-r-plus`                                  | `openextract[cohere]` |
+| Hugging Face | `huggingface:meta-llama/Llama-3.3-70B-Instruct`          | `openextract[huggingface]` |
+| Groq         | `groq:llama-3.3-70b-versatile`                           | `openextract[groq]` |
+| Cerebras     | `cerebras:llama3.1-70b`                                  | `openextract[openai]` |
+| Mistral      | `mistral:mistral-large-latest`                           | `openextract[mistral]` |
+| OpenRouter   | `openrouter:anthropic/claude-sonnet-4`                   | `openextract[openrouter]` |
+| Outlines     | `outlines:transformers/meta-llama/Llama-3.2-1B-Instruct` | Install the matching `pydantic-ai-slim[outlines-*]` backend |
+| Ollama       | `ollama:llama3`                                          | `openextract[openai]` |
 
 Ollama and Cerebras work via the `openai`-compatible code path &mdash; no dedicated extra is required for either.
 
@@ -204,6 +204,12 @@ cat ./reports/q4.pdf | openextract - \
 Exit codes: `0` success, `2` URL fetch error, `3` schema validation error, `4` model error,
 `5` other extraction error, `6` missing provider extra, `7` partial batch failure
 (`--continue-on-error`), `1` any other failure (including bad `--schema` paths).
+
+Extraction errors are written to stderr; successful JSON, usage payloads, and
+`--continue-on-error` batch arrays are written to stdout. Missing provider extras
+exit `6` and include the same install hint as the Python API, for example
+`pip install 'openextract[xai]'`. Partial batch failures with `--continue-on-error`
+still print the full batch array to stdout, write a warning to stderr, and exit `7`.
 
 ## Examples
 
@@ -327,11 +333,10 @@ the compatibility notes below even though it is not exported from `__all__`.
 | `SchemaValidationError` | Stable | Raised when model output cannot be validated against the requested schema. |
 | `ModelError` | Stable | Raised for provider/model API failures. Provider-specific classifiers may expand without changing the public type. |
 | `ProviderNotInstalledError` | Stable | Raised when the requested model provider extra is missing. Install hints may become more specific as providers are added. |
-| `openextract` CLI | Provisional | The command, core flags, JSON output, and documented exit-code categories are intended to remain, but provider-install and partial-batch failure behavior should finish release validation before 0.9. |
+| `openextract` CLI | Provisional | The command, core flags, JSON output, stderr error reporting, provider-install exit code `6`, and partial-batch exit code `7` are intended to remain. |
 
 No pre-1.0 signature changes are currently proposed for stable symbols. Known
-pre-1.0 follow-ups are limited to active-event-loop behavior and final CLI
-release readiness.
+pre-1.0 follow-ups are limited to active-event-loop behavior.
 
 ## Compatibility and deprecation policy
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,10 @@ Install provider extras as needed: `openextract[openai]`, `openextract[anthropic
 
 Set `OPENEXTRACT_MODEL` to override every example with a single model (useful for CI or one-off testing).
 
+If a provider SDK is missing, the Python API raises `ProviderNotInstalledError`
+with a `pip install 'openextract[...]'` hint for known model prefixes. The CLI
+prints the same error to stderr and exits `6`.
+
 ## Prerequisites
 
 ```bash
@@ -69,7 +73,17 @@ PYTHONPATH=. uv run openextract examples/fixtures/document_page.png \
   --schema examples.cli.schemas:DocumentInfo \
   --model anthropic:claude-opus-4-8 \
   --instructions "Two-sentence summary and primary language."
+
+# Batch via CLI, keeping per-item failures in the JSON output
+PYTHONPATH=. uv run openextract examples/fixtures/document_page.png missing.png \
+  --schema examples.cli.schemas:DocumentInfo \
+  --model xai:grok-4.3 \
+  --continue-on-error
 ```
+
+With `--continue-on-error`, successful items and per-item errors are written as
+one JSON array on stdout. If any item fails, the CLI also writes a warning to
+stderr and exits `7`; without the flag, the batch stops at the first failure.
 
 ### Audio
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -313,9 +313,11 @@ class TestMainErrorCodes:
         assert "misc" in capsys.readouterr().err
 
     def test_provider_not_installed_error_returns_6(self, mocker, capsys):
-        exc = ProviderNotInstalledError("install openextract[openai]")
+        exc = ProviderNotInstalledError("Install it with: pip install 'openextract[openai]'")
         assert self._invoke(mocker, exc) == 6
-        assert "openextract[openai]" in capsys.readouterr().err
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "pip install 'openextract[openai]'" in captured.err
 
     def test_bad_schema_module_returns_1(self, capsys):
         exit_code = main(
@@ -430,6 +432,7 @@ class TestMainBatchAndUsage:
         assert '"name": "Ada"' in captured.out  # the successful item is still emitted
         assert '"error_type": "ModelError"' in captured.out
         assert '"input": "b.pdf"' in captured.out
+        assert "warning:" not in captured.out
         assert "1 of 2 input(s) failed" in captured.err
 
     def test_continue_on_error_all_success_exits_0(self, mocker, capsys):

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -706,6 +706,13 @@ class TestProviderNotInstalled:
             ("openai:gpt-4o", "openextract[openai]"),
             ("anthropic:claude-sonnet-4-20250514", "openextract[anthropic]"),
             ("google-gla:gemini-2.5-flash", "openextract[google]"),
+            ("google-vertex:gemini-2.5-pro", "openextract[google]"),
+            ("bedrock:anthropic.claude-sonnet-4-20250514-v1:0", "openextract[bedrock]"),
+            ("cohere:command-r-plus", "openextract[cohere]"),
+            ("groq:llama-3.3-70b-versatile", "openextract[groq]"),
+            ("huggingface:meta-llama/Llama-3.3-70B-Instruct", "openextract[huggingface]"),
+            ("mistral:mistral-large-latest", "openextract[mistral]"),
+            ("openrouter:anthropic/claude-sonnet-4", "openextract[openrouter]"),
             ("xai:grok-4.3", "openextract[xai]"),
             ("cerebras:llama-3.3-70b", "openextract[openai]"),
             ("ollama:llama3.2", "openextract[openai]"),
@@ -727,7 +734,7 @@ class TestProviderNotInstalled:
             extract(schema=_Person, model="openai:gpt-4o", input_file=str(local))
 
         message = str(exc_info.value)
-        assert "openextract[openai]" in message
+        assert "pip install 'openextract[openai]'" in message
         assert "No module named 'openai'" in message
 
     def test_provider_not_installed_is_extraction_error(self):


### PR DESCRIPTION
## Summary

Finish the release-readiness pass for provider install errors and CLI partial batch failures.

Closes #118.

## Changes

- Document provider-specific install extras and missing-provider install hints in the README.
- Clarify CLI stdout/stderr and exit-code behavior for missing provider extras and `--continue-on-error` partial failures.
- Add examples README coverage for CLI provider install failures and partial batch behavior.
- Expand regression coverage for provider prefix install hints and CLI stdout/stderr contracts.
- Add an Unreleased changelog entry for the release-readiness documentation.

## Testing

- `uv run pytest tests/test_extract.py tests/test_cli.py -q`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest -q`
- `uv run pytest --cov=openextract --cov-report=term-missing --cov-fail-under=0`
- `uv run coverage report --fail-under=100`
- `git diff --check`

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Documentation updated (if applicable)
