### PR TITLE
Retry only transient model failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ timing when that is known.
 - Expanded `SECURITY.md` URL input security model (schemes, host validation,
   redirects, env configuration, and non-guarantees).
 
+### Changed
+- Model retries now distinguish transient failures from permanent provider
+  errors, honor bounded `Retry-After` values, and expose provider, status,
+  retryability, and retry-after metadata on `ModelError`.
+- Added `retry_max_backoff` to all extraction APIs and
+  `--retry-max-backoff` to the CLI.
+
 ## [0.9.0] - 2026-07-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -101,7 +101,13 @@ result = extract(
 )
 ```
 
-`max_retries` defaults to `0` (single attempt) and must be a non-negative integer. When set, `extract` retries only on `ModelError` and sleeps `retry_backoff * (2 ** attempt)` seconds (with up to 25% jitter) between attempts. `retry_backoff` defaults to `1.0` second and must be positive and finite.
+`max_retries` defaults to `0` (single attempt) and must be a non-negative integer.
+Only transient `ModelError` failures—timeouts, rate limits, and supported 5xx
+responses—are retried; authentication, permission, and invalid-request failures
+fail immediately. Delays use exponential backoff with up to 25% additive jitter,
+bounded by `retry_max_backoff` (60 seconds by default). A valid provider
+`Retry-After` value takes precedence but is still bounded. Both backoff values
+must be finite and non-negative.
 
 The input is resolved once before the first model attempt. Retries reuse the same
 media bytes, prompt, and agent, so URLs and non-seekable streams are not fetched
@@ -200,7 +206,8 @@ cat ./reports/q4.pdf | openextract - \
 - `--media-type` sets MIME type for stdin or overrides guessing for paths/URLs.
 - `--usage` prints a JSON object with `result` and `usage` (single input only).
 - `--output` is `json` (default) or `repr`.
-- `--max-retries` / `--retry-backoff` match the Python API retry behavior.
+- `--max-retries`, `--retry-backoff`, and `--retry-max-backoff` match the Python
+  API retry behavior.
 - `--continue-on-error` (batch only) keeps processing when an input fails; each
   failure is emitted inline as `{"input", "error", "error_type"}` and the command
   exits `7` if any input failed. Without it, a batch aborts on the first failure.
@@ -253,8 +260,9 @@ except SchemaValidationError:
     ...  # The model's output did not match your schema
 except ProviderNotInstalledError:
     ...  # The provider extra isn't installed (e.g. pip install openextract[xai])
-except ModelError:
-    ...  # The model provider returned an error
+except ModelError as exc:
+    # Structured fields are populated when the provider exposes them.
+    print(exc.provider, exc.status_code, exc.retryable, exc.retry_after)
 except ExtractionError:
     ...  # Any other extraction failure (base class)
 ```
@@ -263,7 +271,7 @@ All `openextract` exceptions inherit from `ExtractionError`, so you can catch it
 
 ## API reference
 
-### `extract(schema, model, input_file, instructions=None, *, media_type=None, max_retries=0, retry_backoff=1.0)`
+### `extract(schema, model, input_file, instructions=None, *, media_type=None, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
 
 | Argument        | Type                          | Description                                                                                                       |
 | --------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------- |
@@ -272,26 +280,27 @@ All `openextract` exceptions inherit from `ExtractionError`, so you can catch it
 | `input_file`    | `str \| bytes \| BinaryIO`    | A local file path, an `https://` URL, raw `bytes`, or a binary file-like object with a `.read()` method.          |
 | `instructions`  | `str \| None`                 | Optional natural-language guidance for the model.                                                                 |
 | `media_type`    | `str \| None` (keyword-only)  | MIME type. Required for `bytes` and file-like inputs; overrides the guessed type for `str` inputs when provided.  |
-| `max_retries`   | `int` (keyword-only)          | Extra attempts after a `ModelError`. Must be a non-negative integer. Defaults to `0` (no retry).                 |
-| `retry_backoff` | `float` (keyword-only)        | Base seconds for exponential backoff with jitter between retries. Must be positive and finite.                   |
+| `max_retries`   | `int` (keyword-only)          | Extra attempts after a transient `ModelError`. Must be a non-negative integer. Defaults to `0` (no retry).       |
+| `retry_backoff` | `float` (keyword-only)        | Base seconds for exponential backoff with jitter. Must be non-negative and finite.                               |
+| `retry_max_backoff` | `float` (keyword-only)    | Maximum retry delay, including `Retry-After`. Must be non-negative and finite. Defaults to `60.0`.               |
 
 Returns an instance of `schema`.
 
-### `extract_async(schema, model, input_file, instructions=None, *, media_type=None, max_retries=0, retry_backoff=1.0)`
+### `extract_async(schema, model, input_file, instructions=None, *, media_type=None, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
 
-Async counterpart to `extract`. Uses `Agent.run` instead of `run_sync`. Accepts the same `schema`, `model`, `input_file`, `instructions`, `media_type`, `max_retries`, and `retry_backoff` arguments.
+Async counterpart to `extract`. Uses `Agent.run` instead of `run_sync` and accepts the same arguments.
 
 Returns an instance of `schema`.
 
-### `extract_with_usage(schema, model, input_file, instructions=None, *, media_type=None, max_retries=0, retry_backoff=1.0)`
+### `extract_with_usage(schema, model, input_file, instructions=None, *, media_type=None, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
 
 Like `extract`, but returns `(output, Usage)` where `Usage` is a frozen dataclass with `input_tokens`, `output_tokens`, and `total_tokens`. Useful for cost tracking and logging. Uses the same `ModelError` retry behavior as `extract`.
 
-### `extract_with_usage_async(schema, model, input_file, instructions=None, *, media_type=None, max_retries=0, retry_backoff=1.0)`
+### `extract_with_usage_async(schema, model, input_file, instructions=None, *, media_type=None, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
 
 Async sibling of `extract_with_usage`; returns `(output, Usage)`.
 
-### `extract_many(schema, model, input_files, instructions=None, *, media_type=None, max_concurrency=5, return_exceptions=False, max_retries=0, retry_backoff=1.0)`
+### `extract_many(schema, model, input_files, instructions=None, *, media_type=None, max_concurrency=5, return_exceptions=False, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
 
 Run concurrent extractions from synchronous code. Each item in `input_files` is a path, URL, `bytes`, or file-like object (same rules as `extract`). Results are returned in input order.
 
@@ -306,12 +315,13 @@ Do not call `extract_many` from a running event loop (for example inside
 | `media_type`         | `str \| None` (keyword-only) | Applied uniformly to every item; required if any item is `bytes`/file-like. |
 | `max_concurrency`    | `int` (keyword-only)         | Maximum in-flight extractions. Must be a positive integer. Defaults to `5`. |
 | `return_exceptions`  | `bool` (keyword-only)        | If `True`, exceptions appear in the result list instead of being raised.    |
-| `max_retries`        | `int` (keyword-only)         | Per-item extra attempts after a `ModelError`. Must be a non-negative integer. Defaults to `0`. |
-| `retry_backoff`      | `float` (keyword-only)       | Base seconds for per-item exponential backoff with jitter. Must be positive and finite. |
+| `max_retries`        | `int` (keyword-only)         | Per-item extra attempts after a transient `ModelError`. Must be a non-negative integer. Defaults to `0`. |
+| `retry_backoff`      | `float` (keyword-only)       | Base seconds for per-item exponential backoff with jitter. Must be non-negative and finite. |
+| `retry_max_backoff`  | `float` (keyword-only)       | Maximum per-item retry delay, including `Retry-After`. Defaults to `60.0`. |
 
 Returns a `list` of schema instances (or exceptions when `return_exceptions=True`).
 
-### `extract_many_async(schema, model, input_files, instructions=None, *, media_type=None, max_concurrency=5, return_exceptions=False, max_retries=0, retry_backoff=1.0)`
+### `extract_many_async(schema, model, input_files, instructions=None, *, media_type=None, max_concurrency=5, return_exceptions=False, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
 
 Async sibling of `extract_many`; same arguments and return shape.
 
@@ -344,7 +354,7 @@ the compatibility notes below even though it is not exported from `__all__`.
 | `ExtractionError` | Stable | Base class for all public `openextract` exceptions. Catch this for a broad fallback. |
 | `UrlFetchError` | Stable | Raised for URL fetch and URL safety failures. Message wording may improve, but the exception type is stable. |
 | `SchemaValidationError` | Stable | Raised when model output cannot be validated against the requested schema. |
-| `ModelError` | Stable | Raised for provider/model API failures. Provider-specific classifiers may expand without changing the public type. |
+| `ModelError` | Stable | Raised for provider/model API failures, with `provider`, `status_code`, `retryable`, and `retry_after` metadata where available. |
 | `ProviderNotInstalledError` | Stable | Raised when the requested model provider extra is missing. Install hints may become more specific as providers are added. |
 | `openextract` CLI | Provisional | The command, core flags, JSON output, stderr error reporting, provider-install exit code `6`, and partial-batch exit code `7` are intended to remain. |
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -129,6 +129,14 @@ openextract ./ok.pdf ./missing.pdf \
 - Without `--continue-on-error`, the first failure aborts and maps to exit codes
   `2`–`6` / `1` as usual (no batch array).
 
+## Retry policy
+
+`--max-retries` enables retries for transient model failures only.
+`--retry-backoff` controls exponential backoff with up to 25% additive jitter,
+and `--retry-max-backoff` caps both calculated delays and provider
+`Retry-After` values. Authentication, permission, and invalid-request failures
+exit immediately with code `4`.
+
 ## Related docs
 
 - [Troubleshooting](troubleshooting.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -103,18 +103,21 @@ Provider/model API failure (auth, rate limit, server error, unsupported media).
 **Next step**
 
 ```python
-extract(..., max_retries=3, retry_backoff=1.0)
+extract(..., max_retries=3, retry_backoff=1.0, retry_max_backoff=60.0)
 ```
 
 CLI:
 
 ```bash
 openextract ./file.pdf --schema pkg:Model --model openai:gpt-5 \
-  --max-retries 3 --retry-backoff 1.0
+  --max-retries 3 --retry-backoff 1.0 --retry-max-backoff 60.0
 ```
 
-Retries apply only to `ModelError`. Invalid option values raise `ValueError`
-(CLI exit `1`).
+Retries apply only when `ModelError.retryable` is true. Rate limits, transient
+transport failures, and supported 5xx responses retry; authentication,
+permission, and invalid-request failures do not. Provider `Retry-After` values
+take precedence over exponential backoff but remain bounded by
+`retry_max_backoff`. Invalid option values raise `ValueError` (CLI exit `1`).
 
 ## CLI schema import errors
 

--- a/src/openextract/_cli.py
+++ b/src/openextract/_cli.py
@@ -166,6 +166,13 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="SECONDS",
         help="Base backoff in seconds for retry (default 1.0).",
     )
+    parser.add_argument(
+        "--retry-max-backoff",
+        type=float,
+        default=60.0,
+        metavar="SECONDS",
+        help="Maximum retry delay in seconds, including Retry-After (default 60.0).",
+    )
     return parser
 
 
@@ -205,6 +212,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     media_type=media_type,
                     max_retries=args.max_retries,
                     retry_backoff=args.retry_backoff,
+                    retry_max_backoff=args.retry_max_backoff,
                 )
                 payload: Any = {"result": result.model_dump(), "usage": _usage_payload(usage)}
             else:
@@ -216,6 +224,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     media_type=media_type,
                     max_retries=args.max_retries,
                     retry_backoff=args.retry_backoff,
+                    retry_max_backoff=args.retry_max_backoff,
                 )
         else:
             results = extract_many(
@@ -226,6 +235,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 media_type=media_type,
                 max_retries=args.max_retries,
                 retry_backoff=args.retry_backoff,
+                retry_max_backoff=args.retry_max_backoff,
                 return_exceptions=args.continue_on_error,
             )
             payload, batch_failures = _batch_payload(results, input_files)

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -9,9 +9,10 @@ import os
 import random
 import socket
 import time
-from collections.abc import Awaitable, Callable, Iterable, Iterator
+from collections.abc import Awaitable, Callable, Iterable, Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import BinaryIO, TypeVar, cast
 from urllib.parse import urlparse
@@ -36,12 +37,46 @@ _DEFAULT_MEDIA_TYPE = "application/octet-stream"
 _URL_PREFIXES = ("http://", "https://")
 _DEFAULT_URL_FETCH_TIMEOUT = 30.0
 _DEFAULT_MAX_REDIRECTS = 10
+_DEFAULT_RETRY_MAX_BACKOFF = 60.0
 _URL_TIMEOUT_ENV = "OPENEXTRACT_URL_TIMEOUT"
 _MAX_REDIRECTS_ENV = "OPENEXTRACT_MAX_REDIRECTS"
 _ALLOW_PRIVATE_URLS_ENV = "OPENEXTRACT_ALLOW_PRIVATE_URLS"
 _BYTES_MEDIA_TYPE_REQUIRED = (
     "media_type is required when input_file is bytes or a file-like object; "
     "pass it explicitly, e.g. extract(..., media_type='application/pdf')."
+)
+_TRANSIENT_HTTP_STATUSES = frozenset((408, 409, 425, 429))
+_PROVIDER_MODULE_NAMES: tuple[tuple[str, str], ...] = (
+    ("openai", "openai"),
+    ("anthropic", "anthropic"),
+    ("google", "google"),
+    ("botocore", "bedrock"),
+    ("cohere", "cohere"),
+    ("huggingface_hub", "huggingface"),
+    ("groq", "groq"),
+    ("mistralai", "mistral"),
+    ("grpc", "xai"),
+)
+_TRANSIENT_ERROR_NAMES = (
+    "timeout",
+    "connection",
+    "ratelimit",
+    "throttl",
+    "resourceexhausted",
+    "servererror",
+    "internalserver",
+    "serviceunavailable",
+)
+_PERMANENT_ERROR_NAMES = (
+    "authentication",
+    "permission",
+    "forbidden",
+    "badrequest",
+    "invalidrequest",
+    "validation",
+    "unprocessable",
+    "notfound",
+    "accessdenied",
 )
 
 # (module, attribute) pairs for provider/model error base classes we want to
@@ -53,6 +88,7 @@ _PROVIDER_ERROR_PATHS: tuple[tuple[str, str], ...] = (
     ("anthropic", "APIError"),
     ("google.genai.errors", "APIError"),
     ("botocore.exceptions", "ClientError"),
+    ("botocore.exceptions", "BotoCoreError"),
     ("cohere.core.api_error", "ApiError"),
     ("huggingface_hub.errors", "HfHubHTTPError"),
     ("groq", "APIError"),
@@ -394,6 +430,132 @@ def _build_run_inputs(file_bytes: bytes, file_type: str) -> list:
     ]
 
 
+def _model_provider(exc: BaseException) -> str | None:
+    """Return a stable provider identifier when the exception exposes one."""
+    model_name = getattr(exc, "model_name", None)
+    if isinstance(model_name, str) and ":" in model_name:
+        return model_name.split(":", 1)[0]
+
+    for error_type in type(exc).__mro__:
+        module = error_type.__module__
+        for prefix, provider in _PROVIDER_MODULE_NAMES:
+            if module == prefix or module.startswith(f"{prefix}."):
+                return provider
+    return None
+
+
+def _model_status_code(exc: BaseException) -> int | None:
+    """Extract an HTTP status code from common provider exception shapes."""
+    status_code = getattr(exc, "status_code", None)
+    if isinstance(status_code, int) and not isinstance(status_code, bool):
+        return status_code
+
+    response = getattr(exc, "response", None)
+    if response is None:
+        response = getattr(exc, "raw_response", None)
+    response_status = getattr(response, "status_code", None)
+    if isinstance(response_status, int) and not isinstance(response_status, bool):
+        return response_status
+
+    if isinstance(response, Mapping):
+        metadata = response.get("ResponseMetadata", {})
+        if isinstance(metadata, Mapping):
+            metadata_status = metadata.get("HTTPStatusCode")
+            if isinstance(metadata_status, int) and not isinstance(metadata_status, bool):
+                return metadata_status
+
+    code = getattr(exc, "code", None)
+    if isinstance(code, int) and not isinstance(code, bool):
+        return code
+    return None
+
+
+def _parse_retry_after(value: object) -> float | None:
+    """Parse Retry-After seconds or an HTTP date into a non-negative duration."""
+    if not isinstance(value, str | int | float) or isinstance(value, bool):
+        return None
+    try:
+        seconds = float(value)
+    except ValueError:
+        try:
+            retry_at = parsedate_to_datetime(str(value))
+        except (TypeError, ValueError, OverflowError):
+            return None
+        seconds = retry_at.timestamp() - time.time()
+    if not math.isfinite(seconds) or seconds < 0:
+        return None
+    return seconds
+
+
+def _model_retry_after(exc: BaseException) -> float | None:
+    """Extract and parse Retry-After from common provider header containers."""
+    direct_value = getattr(exc, "retry_after", None)
+    if direct_value is not None:
+        parsed_value = _parse_retry_after(direct_value)
+        if parsed_value is not None:
+            return parsed_value
+
+    header_sets: list[Mapping] = []
+    headers = getattr(exc, "headers", None)
+    if isinstance(headers, Mapping):
+        header_sets.append(headers)
+
+    response = getattr(exc, "response", None)
+    if response is None:
+        response = getattr(exc, "raw_response", None)
+    response_headers = getattr(response, "headers", None)
+    if isinstance(response_headers, Mapping):
+        header_sets.append(response_headers)
+    if isinstance(response, Mapping):
+        metadata = response.get("ResponseMetadata", {})
+        if isinstance(metadata, Mapping):
+            metadata_headers = metadata.get("HTTPHeaders", {})
+            if isinstance(metadata_headers, Mapping):
+                header_sets.append(metadata_headers)
+
+    for header_set in header_sets:
+        for key, value in header_set.items():
+            if str(key).lower() == "retry-after":
+                return _parse_retry_after(value)
+    return None
+
+
+def _model_error_name(exc: BaseException) -> str:
+    """Normalize provider class names and structured error codes for policy checks."""
+    names = "".join(error_type.__name__ for error_type in type(exc).__mro__).lower()
+    response = getattr(exc, "response", None)
+    if isinstance(response, Mapping):
+        error = response.get("Error", {})
+        if isinstance(error, Mapping):
+            names += str(error.get("Code", "")).lower()
+    return names.replace("_", "")
+
+
+def _is_transient_model_exception(exc: BaseException, status_code: int | None) -> bool:
+    """Classify only known transient provider failures as retryable."""
+    if status_code is not None:
+        return status_code in _TRANSIENT_HTTP_STATUSES or 500 <= status_code <= 599
+
+    code = getattr(exc, "code", None)
+    if callable(code):
+        grpc_name = getattr(code(), "name", "").lower().replace("_", "")
+        if grpc_name in {
+            "deadlineexceeded",
+            "resourceexhausted",
+            "aborted",
+            "unavailable",
+            "internal",
+        }:
+            return True
+        if grpc_name:
+            return False
+
+    error_name = _model_error_name(exc)
+    if any(name in error_name for name in _PERMANENT_ERROR_NAMES):
+        return False
+    return any(name in error_name for name in _TRANSIENT_ERROR_NAMES)
+
+
 def _map_exception(exc: BaseException) -> ExtractionError:
     """Translate a low-level exception into the appropriate ExtractionError subclass."""
     if isinstance(exc, httpx.HTTPStatusError):
@@ -403,7 +565,14 @@ def _map_exception(exc: BaseException) -> ExtractionError:
     if isinstance(exc, ValidationError):
         return SchemaValidationError(f"Model output did not match schema: {exc}")
     if isinstance(exc, _collect_model_error_types()):
-        return ModelError(f"Model API error: {exc}")
+        status_code = _model_status_code(exc)
+        return ModelError(
+            f"Model API error: {exc}",
+            provider=_model_provider(exc),
+            status_code=status_code,
+            retryable=_is_transient_model_exception(exc, status_code),
+            retry_after=_model_retry_after(exc),
+        )
     return ExtractionError(f"Extraction failed: {exc}")
 
 
@@ -533,20 +702,43 @@ async def _run_extraction_async(agent: Agent, inputs: list):
         return await agent.run(inputs)
 
 
-def _retry_delay(retry_backoff: float, attempt: int) -> float:
-    return retry_backoff * (2**attempt) * (1 + random.uniform(0, 0.25))
+def _retry_delay(
+    retry_backoff: float,
+    retry_max_backoff: float,
+    attempt: int,
+    retry_after: float | None,
+) -> float:
+    """Return bounded exponential backoff with up to 25% additive jitter."""
+    if retry_after is not None:
+        return min(retry_after, retry_max_backoff)
+    try:
+        delay = retry_backoff * (2**attempt) * (1 + random.uniform(0, 0.25))
+    except OverflowError:
+        return retry_max_backoff
+    return min(delay, retry_max_backoff)
 
 
-def _validate_retry_options(max_retries: object, retry_backoff: object) -> None:
+def _validate_retry_options(
+    max_retries: object,
+    retry_backoff: object,
+    retry_max_backoff: object,
+) -> None:
     if isinstance(max_retries, bool) or not isinstance(max_retries, int) or max_retries < 0:
         raise ValueError("max_retries must be a non-negative integer.")
     if (
         isinstance(retry_backoff, bool)
         or not isinstance(retry_backoff, int | float)
         or not math.isfinite(retry_backoff)
-        or retry_backoff <= 0
+        or retry_backoff < 0
     ):
-        raise ValueError("retry_backoff must be a finite positive number of seconds.")
+        raise ValueError("retry_backoff must be a finite non-negative number of seconds.")
+    if (
+        isinstance(retry_max_backoff, bool)
+        or not isinstance(retry_max_backoff, int | float)
+        or not math.isfinite(retry_max_backoff)
+        or retry_max_backoff < 0
+    ):
+        raise ValueError("retry_max_backoff must be a finite non-negative number of seconds.")
 
 
 def _validate_max_concurrency(max_concurrency: object) -> None:
@@ -563,17 +755,18 @@ def _run_with_retries_sync[R](
     *,
     max_retries: int,
     retry_backoff: float,
+    retry_max_backoff: float,
 ) -> R:
-    """Run ``fn`` until it succeeds or ``ModelError`` retries are exhausted."""
-    _validate_retry_options(max_retries, retry_backoff)
+    """Run ``fn`` until it succeeds or transient retries are exhausted."""
+    _validate_retry_options(max_retries, retry_backoff, retry_max_backoff)
     attempt = 0
     while True:
         try:
             return fn()
-        except ModelError:
-            if attempt >= max_retries:
+        except ModelError as exc:
+            if not exc.retryable or attempt >= max_retries:
                 raise
-            time.sleep(_retry_delay(retry_backoff, attempt))
+            time.sleep(_retry_delay(retry_backoff, retry_max_backoff, attempt, exc.retry_after))
             attempt += 1
 
 
@@ -582,17 +775,20 @@ async def _run_with_retries_async[R](
     *,
     max_retries: int,
     retry_backoff: float,
+    retry_max_backoff: float,
 ) -> R:
     """Async counterpart to :func:`_run_with_retries_sync`."""
-    _validate_retry_options(max_retries, retry_backoff)
+    _validate_retry_options(max_retries, retry_backoff, retry_max_backoff)
     attempt = 0
     while True:
         try:
             return await fn()
-        except ModelError:
-            if attempt >= max_retries:
+        except ModelError as exc:
+            if not exc.retryable or attempt >= max_retries:
                 raise
-            await asyncio.sleep(_retry_delay(retry_backoff, attempt))
+            await asyncio.sleep(
+                _retry_delay(retry_backoff, retry_max_backoff, attempt, exc.retry_after)
+            )
             attempt += 1
 
 
@@ -605,6 +801,7 @@ def extract(
     media_type: str | None = None,
     max_retries: int = 0,
     retry_backoff: float = 1.0,
+    retry_max_backoff: float = _DEFAULT_RETRY_MAX_BACKOFF,
 ) -> T:
     """
     Extract structured data from a document, image, audio, or video file using an LLM.
@@ -618,12 +815,13 @@ def extract(
         instructions: Optional natural-language guidance for the LLM.
         media_type: Optional MIME type. Required for ``bytes`` and file-like
             inputs; overrides the guess for ``str`` inputs when provided.
-        max_retries: Number of additional attempts to make after a ``ModelError``.
-            Defaults to 0 (no retries, single attempt). Only ``ModelError``
-            triggers a retry; other exceptions propagate immediately.
+        max_retries: Number of additional attempts after a transient
+            ``ModelError``. Defaults to 0 (no retries, single attempt).
         retry_backoff: Base backoff in seconds. Sleep between attempts is
             ``retry_backoff * (2 ** attempt) * (1 + random.uniform(0, 0.25))``,
             i.e. exponential backoff with up to 25% jitter.
+        retry_max_backoff: Maximum delay in seconds for exponential backoff or
+            a provider ``Retry-After`` value. Defaults to 60 seconds.
 
     Returns:
         An instance of the schema populated with extracted data.
@@ -636,12 +834,13 @@ def extract(
         ModelError: If retries (if any) are exhausted.
         ExtractionError: For other extraction failures.
     """
-    _validate_retry_options(max_retries, retry_backoff)
+    _validate_retry_options(max_retries, retry_backoff, retry_max_backoff)
     agent, inputs = _prepare_extraction(schema, model, input_file, instructions, media_type)
     return _run_with_retries_sync(
         lambda: _extract_once(agent, inputs),
         max_retries=max_retries,
         retry_backoff=retry_backoff,
+        retry_max_backoff=retry_max_backoff,
     )
 
 
@@ -654,20 +853,26 @@ def extract_with_usage(
     media_type: str | None = None,
     max_retries: int = 0,
     retry_backoff: float = 1.0,
+    retry_max_backoff: float = _DEFAULT_RETRY_MAX_BACKOFF,
 ) -> tuple[T, Usage]:
     """Extract structured data and return ``(output, Usage)`` for token accounting.
 
     Same retry semantics as :func:`extract`. Returns a :class:`Usage` describing
     the tokens consumed by the successful model call.
     """
-    _validate_retry_options(max_retries, retry_backoff)
+    _validate_retry_options(max_retries, retry_backoff, retry_max_backoff)
     agent, inputs = _prepare_extraction(schema, model, input_file, instructions, media_type)
 
     def _once() -> tuple[T, Usage]:
         result = _run_extraction(agent, inputs)
         return cast(T, result.output), _usage_from_result(result)
 
-    return _run_with_retries_sync(_once, max_retries=max_retries, retry_backoff=retry_backoff)
+    return _run_with_retries_sync(
+        _once,
+        max_retries=max_retries,
+        retry_backoff=retry_backoff,
+        retry_max_backoff=retry_max_backoff,
+    )
 
 
 async def extract_with_usage_async(
@@ -679,9 +884,10 @@ async def extract_with_usage_async(
     media_type: str | None = None,
     max_retries: int = 0,
     retry_backoff: float = 1.0,
+    retry_max_backoff: float = _DEFAULT_RETRY_MAX_BACKOFF,
 ) -> tuple[T, Usage]:
     """Async sibling of :func:`extract_with_usage`; returns ``(output, Usage)``."""
-    _validate_retry_options(max_retries, retry_backoff)
+    _validate_retry_options(max_retries, retry_backoff, retry_max_backoff)
     agent, inputs = await _prepare_extraction_async(
         schema,
         model,
@@ -698,6 +904,7 @@ async def extract_with_usage_async(
         _once,
         max_retries=max_retries,
         retry_backoff=retry_backoff,
+        retry_max_backoff=retry_max_backoff,
     )
 
 
@@ -710,9 +917,10 @@ async def extract_async(
     media_type: str | None = None,
     max_retries: int = 0,
     retry_backoff: float = 1.0,
+    retry_max_backoff: float = _DEFAULT_RETRY_MAX_BACKOFF,
 ) -> T:
     """Async sibling of :func:`extract`; uses ``Agent.run`` instead of ``run_sync``."""
-    _validate_retry_options(max_retries, retry_backoff)
+    _validate_retry_options(max_retries, retry_backoff, retry_max_backoff)
     agent, inputs = await _prepare_extraction_async(
         schema,
         model,
@@ -729,6 +937,7 @@ async def extract_async(
         _once,
         max_retries=max_retries,
         retry_backoff=retry_backoff,
+        retry_max_backoff=retry_max_backoff,
     )
 
 
@@ -755,8 +964,9 @@ async def _gather_extractions(
     media_type: str | None,
     max_retries: int,
     retry_backoff: float,
+    retry_max_backoff: float,
 ) -> list:
-    _validate_retry_options(max_retries, retry_backoff)
+    _validate_retry_options(max_retries, retry_backoff, retry_max_backoff)
     _validate_max_concurrency(max_concurrency)
     files = list(input_files)
     if not files:
@@ -784,6 +994,7 @@ async def _gather_extractions(
                     _once,
                     max_retries=max_retries,
                     retry_backoff=retry_backoff,
+                    retry_max_backoff=retry_max_backoff,
                 )
 
         tasks = [_bounded(item) for item in files]
@@ -801,6 +1012,7 @@ def extract_many(
     return_exceptions: bool = False,
     max_retries: int = 0,
     retry_backoff: float = 1.0,
+    retry_max_backoff: float = _DEFAULT_RETRY_MAX_BACKOFF,
 ) -> list:
     """Run :func:`extract_async` over many inputs concurrently from sync code.
 
@@ -818,17 +1030,18 @@ def extract_many(
         max_retries: Per-item retries after ``ModelError`` (same semantics as
             :func:`extract`).
         retry_backoff: Base backoff seconds between per-item retries.
+        retry_max_backoff: Maximum per-item retry delay in seconds.
 
     Returns:
         A list of results (or exceptions, when ``return_exceptions=True``) in input order.
 
     Raises:
         ValueError: If ``max_concurrency`` is less than 1, ``max_retries`` is
-            negative, or ``retry_backoff`` is not positive and finite.
+            negative, or a backoff value is negative or non-finite.
         RuntimeError: If called from a running event loop. Use
             :func:`extract_many_async` in async code instead.
     """
-    _validate_retry_options(max_retries, retry_backoff)
+    _validate_retry_options(max_retries, retry_backoff, retry_max_backoff)
     _validate_max_concurrency(max_concurrency)
     try:
         asyncio.get_running_loop()
@@ -850,6 +1063,7 @@ def extract_many(
             media_type,
             max_retries,
             retry_backoff,
+            retry_max_backoff,
         )
     )
 
@@ -865,6 +1079,7 @@ async def extract_many_async(
     return_exceptions: bool = False,
     max_retries: int = 0,
     retry_backoff: float = 1.0,
+    retry_max_backoff: float = _DEFAULT_RETRY_MAX_BACKOFF,
 ) -> list:
     """Async sibling of :func:`extract_many`."""
     return await _gather_extractions(
@@ -877,4 +1092,5 @@ async def extract_many_async(
         media_type,
         max_retries,
         retry_backoff,
+        retry_max_backoff,
     )

--- a/src/openextract/exceptions.py
+++ b/src/openextract/exceptions.py
@@ -6,7 +6,33 @@ class ExtractionError(Exception):
 
 
 class ModelError(ExtractionError):
-    """Error communicating with the model API."""
+    """Error communicating with the model API.
+
+    The optional metadata is populated for provider exceptions when available.
+    ``retryable`` defaults to ``True`` so manually raised ``ModelError`` values
+    retain their historical retry behavior.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        provider: str | None = None,
+        status_code: int | None = None,
+        retryable: bool | None = None,
+        retry_after: float | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.provider = provider
+        self.status_code = status_code
+        if retryable is None:
+            retryable = (
+                status_code is None
+                or status_code in {408, 409, 425, 429}
+                or 500 <= status_code <= 599
+            )
+        self.retryable = retryable
+        self.retry_after = retry_after
 
 
 class ProviderNotInstalledError(ExtractionError):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -164,6 +164,7 @@ class TestMainSuccess:
             media_type=None,
             max_retries=0,
             retry_backoff=1.0,
+            retry_max_backoff=60.0,
         )
 
     def test_repr_output(self, mocker, capsys):
@@ -205,7 +206,7 @@ class TestMainSuccess:
         assert exit_code == 0
         assert mock_extract.call_args.kwargs["instructions"] is None
 
-    def test_max_retries_and_retry_backoff_defaults(self, mocker):
+    def test_retry_defaults(self, mocker):
         fake = MagicMock()
         fake.model_dump_json.return_value = "{}"
         mock_extract = _patch_extract(mocker, return_value=fake)
@@ -222,8 +223,9 @@ class TestMainSuccess:
 
         assert mock_extract.call_args.kwargs["max_retries"] == 0
         assert mock_extract.call_args.kwargs["retry_backoff"] == 1.0
+        assert mock_extract.call_args.kwargs["retry_max_backoff"] == 60.0
 
-    def test_max_retries_and_retry_backoff_custom(self, mocker):
+    def test_retry_options_custom(self, mocker):
         fake = MagicMock()
         fake.model_dump_json.return_value = "{}"
         mock_extract = _patch_extract(mocker, return_value=fake)
@@ -239,11 +241,14 @@ class TestMainSuccess:
                 "3",
                 "--retry-backoff",
                 "2.5",
+                "--retry-max-backoff",
+                "12.0",
             ]
         )
 
         assert mock_extract.call_args.kwargs["max_retries"] == 3
         assert mock_extract.call_args.kwargs["retry_backoff"] == 2.5
+        assert mock_extract.call_args.kwargs["retry_max_backoff"] == 12.0
 
     def test_invalid_max_retries_returns_1(self, capsys):
         exit_code = main(
@@ -270,12 +275,28 @@ class TestMainSuccess:
                 "--model",
                 "xai:grok-4.3",
                 "--retry-backoff",
-                "0",
+                "-0.1",
             ]
         )
 
         assert exit_code == 1
         assert "retry_backoff" in capsys.readouterr().err
+
+    def test_invalid_retry_max_backoff_returns_1(self, capsys):
+        exit_code = main(
+            [
+                "input.txt",
+                "--schema",
+                "tests.test_cli:_FixtureSchema",
+                "--model",
+                "xai:grok-4.3",
+                "--retry-max-backoff",
+                "-1",
+            ]
+        )
+
+        assert exit_code == 1
+        assert "retry_max_backoff" in capsys.readouterr().err
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -37,7 +37,13 @@ from openextract._extract import (
     _install_hint,
     _is_public_ip,
     _is_safe_host,
+    _is_transient_model_exception,
+    _map_exception,
     _max_redirects,
+    _model_retry_after,
+    _model_status_code,
+    _parse_retry_after,
+    _retry_delay,
     _run_with_shared_agent,
     _url_fetch_timeout,
 )
@@ -792,6 +798,194 @@ class TestExtract:
             extract(schema=_Person, model="openai:gpt-5", input_file=str(local))
         assert exc_info.value is original
 
+    @pytest.mark.parametrize(
+        "status_code,retryable",
+        [(400, False), (401, False), (403, False), (429, True), (500, True), (503, True)],
+    )
+    def test_model_http_error_preserves_retry_metadata(self, status_code, retryable):
+        from pydantic_ai.exceptions import ModelHTTPError
+
+        provider_error = ModelHTTPError(
+            status_code=status_code,
+            model_name="openai:gpt-5",
+            body="provider failed",
+        )
+        provider_error.headers = {"Retry-After": "12.5"}
+
+        mapped = _map_exception(provider_error)
+
+        assert isinstance(mapped, ModelError)
+        assert mapped.provider == "openai"
+        assert mapped.status_code == status_code
+        assert mapped.retryable is retryable
+        assert mapped.retry_after == 12.5
+
+    def test_transient_transport_model_error_is_retryable(self):
+        from pydantic_ai.exceptions import ModelAPIError
+
+        class APITimeoutError(ModelAPIError):
+            pass
+
+        mapped = _map_exception(APITimeoutError(model_name="anthropic:claude", message="timed out"))
+
+        assert isinstance(mapped, ModelError)
+        assert mapped.provider == "anthropic"
+        assert mapped.status_code is None
+        assert mapped.retryable is True
+        assert mapped.retry_after is None
+
+    def test_bedrock_transport_error_is_retryable(self):
+        from botocore.exceptions import EndpointConnectionError
+
+        mapped = _map_exception(EndpointConnectionError(endpoint_url="https://bedrock.example.com"))
+
+        assert isinstance(mapped, ModelError)
+        assert mapped.provider == "bedrock"
+        assert mapped.status_code is None
+        assert mapped.retryable is True
+
+    def test_unknown_model_error_is_fail_fast(self):
+        from pydantic_ai.exceptions import ModelAPIError
+
+        mapped = _map_exception(ModelAPIError(model_name="custom-model", message="failed"))
+
+        assert isinstance(mapped, ModelError)
+        assert mapped.provider is None
+        assert mapped.retryable is False
+
+    def test_model_error_constructor_remains_backwards_compatible(self):
+        error = ModelError("flaky")
+
+        assert str(error) == "flaky"
+        assert error.provider is None
+        assert error.status_code is None
+        assert error.retryable is True
+        assert error.retry_after is None
+
+    @pytest.mark.parametrize(
+        "status_code,retryable",
+        [(400, False), (401, False), (403, False), (429, True), (503, True)],
+    )
+    def test_model_error_constructor_infers_retryability(self, status_code, retryable):
+        error = ModelError("provider failed", status_code=status_code)
+
+        assert error.retryable is retryable
+
+
+class TestModelErrorMetadataHelpers:
+    def test_status_from_response_object(self):
+        error = Exception("failed")
+        error.response = MagicMock(status_code=502)  # type: ignore[attr-defined]
+
+        assert _model_status_code(error) == 502
+
+    def test_status_and_retry_after_from_raw_response(self):
+        error = Exception("failed")
+        error.raw_response = MagicMock(  # type: ignore[attr-defined]
+            status_code=503,
+            headers={"Retry-After": "8"},
+        )
+
+        assert _model_status_code(error) == 503
+        assert _model_retry_after(error) == 8
+
+    def test_status_from_bedrock_metadata(self):
+        error = Exception("failed")
+        error.response = {  # type: ignore[attr-defined]
+            "ResponseMetadata": {"HTTPStatusCode": 429}
+        }
+
+        assert _model_status_code(error) == 429
+
+    def test_status_from_integer_code(self):
+        error = Exception("failed")
+        error.code = 503  # type: ignore[attr-defined]
+
+        assert _model_status_code(error) == 503
+
+    def test_boolean_status_values_are_ignored(self):
+        error = Exception("failed")
+        error.status_code = True  # type: ignore[attr-defined]
+        error.response = {  # type: ignore[attr-defined]
+            "ResponseMetadata": {"HTTPStatusCode": False}
+        }
+        error.code = True  # type: ignore[attr-defined]
+
+        assert _model_status_code(error) is None
+
+    def test_non_mapping_bedrock_metadata_is_ignored(self):
+        error = Exception("failed")
+        error.response = {"ResponseMetadata": None}  # type: ignore[attr-defined]
+
+        assert _model_status_code(error) is None
+
+    def test_retry_after_from_response_headers(self):
+        error = Exception("failed")
+        error.response = MagicMock(  # type: ignore[attr-defined]
+            headers={"x-request-id": "123", "Retry-After": "7"}
+        )
+
+        assert _model_retry_after(error) == 7
+
+    def test_retry_after_from_direct_attribute(self):
+        error = Exception("failed")
+        error.retry_after = 6  # type: ignore[attr-defined]
+
+        assert _model_retry_after(error) == 6
+
+    def test_invalid_direct_retry_after_falls_back_to_headers(self):
+        error = Exception("failed")
+        error.retry_after = "invalid"  # type: ignore[attr-defined]
+        error.headers = {"Retry-After": "5"}  # type: ignore[attr-defined]
+
+        assert _model_retry_after(error) == 5
+
+    def test_retry_after_from_bedrock_metadata_headers(self):
+        error = Exception("failed")
+        error.response = {  # type: ignore[attr-defined]
+            "ResponseMetadata": {"HTTPHeaders": {"retry-after": "9"}}
+        }
+
+        assert _model_retry_after(error) == 9
+
+    @pytest.mark.parametrize(
+        "response",
+        [
+            {"ResponseMetadata": None},
+            {"ResponseMetadata": {"HTTPHeaders": None}},
+            {"Error": "not-a-mapping"},
+        ],
+    )
+    def test_malformed_response_metadata_is_ignored(self, response):
+        error = Exception("failed")
+        error.response = response  # type: ignore[attr-defined]
+
+        assert _model_retry_after(error) is None
+        assert _is_transient_model_exception(error, None) is False
+
+    def test_permanent_error_name_is_not_transient(self):
+        class AuthenticationError(Exception):
+            pass
+
+        assert _is_transient_model_exception(AuthenticationError(), None) is False
+
+    def test_permanent_grpc_status_is_not_transient(self):
+        class _Code:
+            name = "PERMISSION_DENIED"
+
+        class _GrpcError(Exception):
+            def code(self):
+                return _Code()
+
+        assert _is_transient_model_exception(_GrpcError(), None) is False
+
+    def test_empty_grpc_status_falls_back_to_class_name(self):
+        class ConnectionError(Exception):
+            def code(self):
+                return object()
+
+        assert _is_transient_model_exception(ConnectionError(), None) is True
+
     def test_extract_returns_only_model_instance(self, tmp_path, mocker):
         """Regression: extract() still returns just the schema instance, not a tuple."""
         local = tmp_path / "input.txt"
@@ -1031,6 +1225,27 @@ class TestExtractWithUsage:
 # ---------------------------------------------------------------------------
 
 
+class TestRetryAfterParsing:
+    @pytest.mark.parametrize("value", ["2.5", 3, 4.5])
+    def test_parses_delta_seconds(self, value):
+        assert _parse_retry_after(value) == float(value)
+
+    def test_parses_http_date(self, mocker):
+        mocker.patch("openextract._extract.time.time", return_value=1445412450.0)
+
+        assert _parse_retry_after("Wed, 21 Oct 2015 07:28:00 GMT") == 30.0
+
+    @pytest.mark.parametrize(
+        "value",
+        [None, True, -1, float("inf"), "not-a-date"],
+    )
+    def test_rejects_invalid_values(self, value):
+        assert _parse_retry_after(value) is None
+
+    def test_extreme_attempt_count_is_bounded_without_overflow(self):
+        assert _retry_delay(1.0, 60.0, 10_000, None) == 60.0
+
+
 class TestExtractRetry:
     def test_invalid_max_retries_is_rejected_before_extraction(self, mocker):
         once = mocker.patch("openextract._extract._extract_once")
@@ -1045,7 +1260,10 @@ class TestExtractRetry:
 
         once.assert_not_called()
 
-    @pytest.mark.parametrize("retry_backoff", [0, -1.0, float("inf"), "slow", True])
+    @pytest.mark.parametrize(
+        "retry_backoff",
+        [-1.0, float("inf"), float("nan"), "slow", True],
+    )
     def test_invalid_retry_backoff_is_rejected_before_extraction(self, mocker, retry_backoff):
         once = mocker.patch("openextract._extract._extract_once")
 
@@ -1058,6 +1276,50 @@ class TestExtractRetry:
             )
 
         once.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "retry_max_backoff",
+        [-1.0, float("inf"), float("nan"), "slow", True],
+    )
+    def test_invalid_retry_max_backoff_is_rejected_before_extraction(
+        self, mocker, retry_max_backoff
+    ):
+        once = mocker.patch("openextract._extract._extract_once")
+
+        with pytest.raises(ValueError, match="retry_max_backoff"):
+            extract(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_file="ignored",
+                retry_max_backoff=retry_max_backoff,  # type: ignore[arg-type]
+            )
+
+        once.assert_not_called()
+
+    def test_zero_backoff_values_are_allowed(self, mocker):
+        expected = _Person(name="Grace", age=85)
+        mocker.patch(
+            "openextract._extract._prepare_extraction",
+            return_value=(MagicMock(), ["prepared"]),
+        )
+        once = mocker.patch(
+            "openextract._extract._extract_once",
+            side_effect=[ModelError("flaky"), expected],
+        )
+        sleep_mock = mocker.patch("openextract._extract.time.sleep")
+
+        result = extract(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_file="ignored",
+            max_retries=1,
+            retry_backoff=0,
+            retry_max_backoff=0,
+        )
+
+        assert result is expected
+        assert once.call_count == 2
+        sleep_mock.assert_called_once_with(0)
 
     def test_no_retry_by_default_raises_immediately(self, mocker):
         sleep_mock = mocker.patch("openextract._extract.time.sleep")
@@ -1100,6 +1362,33 @@ class TestExtractRetry:
         assert once.call_count == 3
         prepare.assert_called_once()
         assert sleep_mock.call_count == 2
+
+    @pytest.mark.parametrize("status_code", [400, 401, 403, 422])
+    def test_permanent_model_errors_are_not_retried(self, mocker, status_code):
+        sleep_mock = mocker.patch("openextract._extract.time.sleep")
+        mocker.patch(
+            "openextract._extract._prepare_extraction",
+            return_value=(MagicMock(), ["prepared"]),
+        )
+        once = mocker.patch(
+            "openextract._extract._extract_once",
+            side_effect=ModelError(
+                "permanent",
+                status_code=status_code,
+                retryable=False,
+            ),
+        )
+
+        with pytest.raises(ModelError, match="permanent"):
+            extract(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_file="ignored",
+                max_retries=3,
+            )
+
+        assert once.call_count == 1
+        sleep_mock.assert_not_called()
 
     def test_retry_exhausted_raises_last_model_error(self, mocker):
         sleep_mock = mocker.patch("openextract._extract.time.sleep")
@@ -1150,6 +1439,53 @@ class TestExtractRetry:
         assert 1.0 <= delays[0] <= 1.25
         assert 2.0 <= delays[1] <= 2.5
         assert 4.0 <= delays[2] <= 5.0
+
+    def test_exponential_backoff_is_bounded(self, mocker):
+        sleep_mock = mocker.patch("openextract._extract.time.sleep")
+        mocker.patch(
+            "openextract._extract._prepare_extraction",
+            return_value=(MagicMock(), ["prepared"]),
+        )
+        mocker.patch(
+            "openextract._extract._extract_once",
+            side_effect=ModelError("nope"),
+        )
+
+        with pytest.raises(ModelError):
+            extract(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_file="ignored",
+                max_retries=2,
+                retry_backoff=10,
+                retry_max_backoff=3,
+            )
+
+        assert [call.args[0] for call in sleep_mock.call_args_list] == [3, 3]
+
+    def test_retry_after_takes_precedence_and_is_bounded(self, mocker):
+        expected = _Person(name="Grace", age=85)
+        mocker.patch(
+            "openextract._extract._prepare_extraction",
+            return_value=(MagicMock(), ["prepared"]),
+        )
+        mocker.patch(
+            "openextract._extract._extract_once",
+            side_effect=[ModelError("rate limited", retry_after=120), expected],
+        )
+        sleep_mock = mocker.patch("openextract._extract.time.sleep")
+
+        result = extract(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_file="ignored",
+            max_retries=1,
+            retry_backoff=0.25,
+            retry_max_backoff=15,
+        )
+
+        assert result is expected
+        sleep_mock.assert_called_once_with(15)
 
     def test_schema_validation_error_is_not_retried(self, mocker):
         sleep_mock = mocker.patch("openextract._extract.time.sleep")
@@ -1249,7 +1585,7 @@ class TestExtractAsyncRetry:
                 schema=_Person,
                 model="openai:gpt-5",
                 input_file="ignored",
-                retry_backoff=0,
+                retry_backoff=-1,
             )
 
         agent_cls.assert_not_called()


### PR DESCRIPTION
## Summary

Classify model failures before retrying, preserve provider metadata, and keep retry delays bounded.

Closes #159

## Changes

- add structured `provider`, `status_code`, `retryable`, and `retry_after` fields to `ModelError`
- retry rate limits, supported 5xx responses, gRPC transient statuses, and provider transport failures
- fail fast for authentication, permission, invalid-request, and other permanent failures
- honor numeric and HTTP-date `Retry-After` values with a configurable `retry_max_backoff` cap
- expose `retry_max_backoff` across sync, async, usage, batch, and CLI APIs
- allow finite non-negative backoff values and guard extreme attempt counts from overflow
- document the retry contract and structured error metadata

## Testing

- `uv run pytest -q --cov=openextract --cov-report=term-missing` (244 passed, 5 skipped; 100% coverage)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `git diff --check`

## Checklist

- [x] Tests pass locally
- [x] Linting passes
- [x] Documentation updated