### PR TITLE
Release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ timing when that is known.
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-08-01
+
 ### Added
 - Explicit `RuntimeError` when `extract_many()` is called from a running event
   loop, directing callers to `extract_many_async`.
@@ -20,11 +22,19 @@ timing when that is known.
   redirects, env configuration, and non-guarantees).
 
 ### Changed
+- Async extraction now keeps disk, DNS, and file-like reads off the event loop
+  and reuses one HTTP client across each batch.
+- Model retries now reuse the original media payload, prompt, and agent instead
+  of reading or fetching the input and rebuilding the agent on every attempt.
 - Model retries now distinguish transient failures from permanent provider
   errors, honor bounded `Retry-After` values, and expose provider, status,
   retryability, and retry-after metadata on `ModelError`.
 - Added `retry_max_backoff` to all extraction APIs and
   `--retry-max-backoff` to the CLI.
+
+### Security
+- Async URL fetching retains redirect-by-redirect public-host and SSRF
+  validation while using async clients and offloaded DNS resolution.
 
 ## [0.9.0] - 2026-07-12
 
@@ -45,10 +55,6 @@ timing when that is known.
   behavior.
 
 ### Changed
-- Async extraction now keeps disk, DNS, and file-like reads off the event loop
-  and reuses one HTTP client across each batch.
-- Model retries now reuse the original media payload, prompt, and agent instead
-  of reading or fetching the input and rebuilding the agent on every attempt.
 - `max_retries`, `retry_backoff`, and `max_concurrency` now fail early with
   deterministic `ValueError` messages when invalid values are provided.
 
@@ -150,7 +156,8 @@ timing when that is known.
 ## [0.1.1] - 2025-09-10
 - Merge pull request #12 from Mellow-Artificial-Intelligence/new-release.
 
-[Unreleased]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.6.0...v0.7.0

--- a/docs/index.html
+++ b/docs/index.html
@@ -93,9 +93,9 @@
           <!-- Badge -->
           <a href="#whats-new" class="animate-slide-up opacity-0 inline-flex items-center gap-2.5 px-3 py-1.5 border border-black/10 bg-white text-xs mb-8 hover:border-black/30 transition-colors">
             <span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>
-            <span class="font-mono text-black/40">v0.8.0</span>
+            <span class="font-mono text-black/40">v0.10.0</span>
             <span class="text-black/40">|</span>
-            <span class="text-black/40">optional extras, CLI batch, retry parity</span>
+            <span class="text-black/40">non-blocking async I/O and smarter retries</span>
           </a>
 
           <!-- Headline -->
@@ -264,15 +264,15 @@
         </div>
       </section>
 
-      <!-- What's new in 0.8.0 -->
+      <!-- What's new in 0.10.0 -->
       <section id="whats-new" class="py-16 sm:py-24 border-t border-black/5 scroll-mt-14">
         <div class="max-w-5xl mx-auto px-4 sm:px-6">
           <div class="flex items-baseline justify-between mb-8 sm:mb-10 flex-wrap gap-3">
             <div>
               <p class="font-mono text-[11px] text-black/40 uppercase tracking-wider mb-2">What&rsquo;s new</p>
-              <h2 class="text-2xl sm:text-3xl font-bold text-black/90">v0.8.0</h2>
+              <h2 class="text-2xl sm:text-3xl font-bold text-black/90">v0.10.0</h2>
             </div>
-            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/CHANGELOG.md#080---2026-06-02" class="font-mono text-xs text-black/40 hover:text-black/90 transition-colors inline-flex items-center gap-1.5">
+            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/CHANGELOG.md#0100---2026-08-01" class="font-mono text-xs text-black/40 hover:text-black/90 transition-colors inline-flex items-center gap-1.5">
               Full changelog <i data-lucide="arrow-up-right" class="w-3 h-3"></i>
             </a>
           </div>
@@ -282,20 +282,17 @@
               <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
                 <i data-lucide="package" class="w-4 h-4 text-black/40"></i>
               </div>
-              <span class="font-mono text-[10px] text-black/40 uppercase tracking-wider">v0.8.0 &middot; Install</span>
+              <span class="font-mono text-[10px] text-black/40 uppercase tracking-wider">v0.10.0 &middot; Performance</span>
             </div>
-            <h3 class="font-mono text-base font-medium text-black/90 mb-2">Slim core, optional provider extras</h3>
+            <h3 class="font-mono text-base font-medium text-black/90 mb-2">Non-blocking media and resilient retries</h3>
             <p class="text-sm text-black/60 leading-relaxed mb-4">
-              <code class="font-mono text-black/90 text-xs">pip install openextract</code> and <code class="font-mono text-black/90 text-xs">uv add openextract</code> ship a lean dependency set. Add the SDK you need for model calls &mdash; for example <code class="font-mono text-black/90 text-xs">openextract[openai]</code> or <code class="font-mono text-black/90 text-xs">openextract[all]</code>.
+              Async APIs now offload disk, DNS, and file-like reads while reusing HTTP clients. Retries reuse prepared inputs and agents, retry only transient failures, and honor bounded <code class="font-mono text-black/90 text-xs">Retry-After</code> values.
             </p>
             <div class="flex flex-wrap gap-1.5">
-              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">[openai]</span>
-              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">[anthropic]</span>
-              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">[google]</span>
-              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">[bedrock]</span>
-              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">[groq]</span>
-              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">[mistral]</span>
-              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">[all]</span>
+              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">async I/O</span>
+              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">client reuse</span>
+              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">transient retries</span>
+              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">Retry-After</span>
             </div>
           </div>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openextract"
-version = "0.9.0"
+version = "0.10.0"
 description = "Extract structured data from documents, images, audio, and video using LLMs"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1229,7 +1229,7 @@ wheels = [
 
 [[package]]
 name = "openextract"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Prepare the 0.10.0 release after merging #167, #168, and #169.

## Release highlights

- Keep async disk, DNS, and file-like reads off the event loop and reuse one HTTP client per batch.
- Reuse prepared media, prompts, and agents across retries.
- Retry only transient provider failures, honor bounded `Retry-After`, and expose retry metadata.
- Add `retry_max_backoff` across the Python API and CLI.
- Refresh the landing page for 0.10.0.

## Release preparation

- [x] Bump `pyproject.toml` and `uv.lock` to 0.10.0.
- [x] Date and reconcile the changelog.
- [x] Call out the SSRF-sensitive async URL-fetching behavior.
- [x] Update version-sensitive landing-page content.
- [x] Run lint, formatting, type checking, tests, and coverage.
- [x] Build and inspect the 0.10.0 sdist and wheel.
- [ ] Refresh the dependency embargo cutoff. The current `exclude-newer` value is `2026-05-15T00:00:00Z`, and there is no open automated embargo PR. This must be resolved before merge.
- [ ] Optional live provider smoke test (requires credentials and explicit opt-in).

## Verification

- `uv sync --locked --dev`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest -v --cov=openextract --cov-report=term-missing` — 260 passed, 5 skipped, 100% coverage
- `uv run coverage report --fail-under=100`
- `uv build` — built `openextract-0.10.0.tar.gz` and `openextract-0.10.0-py3-none-any.whl`

Merging this PR triggers the release workflow, so it should remain draft until the embargo prerequisite is satisfied.