### PR TITLE
Default OpenAI models to Responses API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ timing when that is known.
 
 ## [Unreleased]
 
+### Changed
+- `openai:` model identifiers now use the OpenAI Responses API by default;
+  `openai-chat:` remains available as an explicit Chat Completions opt-in.
+
 ## [0.10.0] - 2026-08-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ print(f"tokens: {usage.input_tokens} in / {usage.output_tokens} out / {usage.tot
 | Outlines     | `outlines:transformers/meta-llama/Llama-3.2-1B-Instruct` | Install the matching `pydantic-ai-slim[outlines-*]` backend |
 | Ollama       | `ollama:llama3`                                          | `openextract[openai]` |
 
+OpenAI identifiers using the concise `openai:` prefix are routed through the
+Responses API by default. Use `openai-responses:` to select it explicitly or
+`openai-chat:` to force the legacy Chat Completions API.
+
 Ollama and Cerebras work via the `openai`-compatible code path &mdash; no dedicated extra is required for either.
 
 Set the corresponding provider credentials in your environment (e.g. `XAI_API_KEY` for xAI). `openextract` loads `.env` automatically.

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,9 @@ Examples use **OpenAI**, **Anthropic**, and **xAI** so you can see how provider 
 
 Install provider extras as needed: `openextract[openai]`, `openextract[anthropic]`, `openextract[xai]`, or `openextract[all]`.
 
+`openai:` model identifiers use the Responses API by default. Use
+`openai-chat:` only when a model specifically requires Chat Completions.
+
 Set `OPENEXTRACT_MODEL` to override every example with a single model (useful for CI or one-off testing).
 
 If a provider SDK is missing, the Python API raises `ProviderNotInstalledError`

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -38,6 +38,8 @@ _URL_PREFIXES = ("http://", "https://")
 _DEFAULT_URL_FETCH_TIMEOUT = 30.0
 _DEFAULT_MAX_REDIRECTS = 10
 _DEFAULT_RETRY_MAX_BACKOFF = 60.0
+_OPENAI_PREFIX = "openai:"
+_OPENAI_RESPONSES_PREFIX = "openai-responses:"
 _URL_TIMEOUT_ENV = "OPENEXTRACT_URL_TIMEOUT"
 _MAX_REDIRECTS_ENV = "OPENEXTRACT_MAX_REDIRECTS"
 _ALLOW_PRIVATE_URLS_ENV = "OPENEXTRACT_ALLOW_PRIVATE_URLS"
@@ -102,6 +104,8 @@ _PROVIDER_ERROR_PATHS: tuple[tuple[str, str], ...] = (
 # listed here fall back to suggesting ``openextract[all]``.
 _PROVIDER_EXTRAS: dict[str, str] = {
     "openai": "openai",
+    "openai-chat": "openai",
+    "openai-responses": "openai",
     "anthropic": "anthropic",
     "google-gla": "google",
     "google-vertex": "google",
@@ -401,6 +405,13 @@ def _install_hint(model: str) -> str:
     return f"pip install '{target}'"
 
 
+def _route_model(model: str) -> str:
+    """Route shorthand OpenAI identifiers through the Responses API."""
+    if model.startswith(_OPENAI_PREFIX):
+        return f"{_OPENAI_RESPONSES_PREFIX}{model.removeprefix(_OPENAI_PREFIX)}"
+    return model
+
+
 def _build_agent(schema: type[T], model: str, instructions: str | None) -> Agent:
     """Construct the pydantic_ai Agent, handling the ollama output-type quirk.
 
@@ -410,7 +421,7 @@ def _build_agent(schema: type[T], model: str, instructions: str | None) -> Agent
     """
     try:
         return Agent(
-            model,
+            _route_model(model),
             instructions=instructions,
             output_type=NativeOutput(schema) if model.startswith("ollama") else schema,
         )

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -637,11 +637,30 @@ class TestExtract:
 
         assert result is expected
         agent_cls.assert_called_once()
+        assert agent_cls.call_args.args == ("openai-responses:gpt-5",)
         # Non-ollama models pass the schema directly as output_type.
         kwargs = agent_cls.call_args.kwargs
         assert kwargs["instructions"] == "pull the person"
         assert kwargs["output_type"] is _Person
         agent_instance.run_sync.assert_called_once()
+
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            ("openai:gpt-5.6-luna", "openai-responses:gpt-5.6-luna"),
+            ("openai-responses:gpt-5.6-luna", "openai-responses:gpt-5.6-luna"),
+            ("openai-chat:gpt-5.6-luna", "openai-chat:gpt-5.6-luna"),
+            ("anthropic:claude-sonnet-4", "anthropic:claude-sonnet-4"),
+        ],
+    )
+    def test_model_routing(self, tmp_path, mocker, model, expected):
+        local = tmp_path / "input.txt"
+        local.write_bytes(b"hello")
+        agent_cls, _ = _make_agent_mock(mocker, output=_Person(name="Ada", age=36))
+
+        extract(schema=_Person, model=model, input_file=str(local))
+
+        assert agent_cls.call_args.args == (expected,)
 
     def test_ollama_model_wraps_output_in_native_output(self, tmp_path, mocker):
         local = tmp_path / "input.txt"
@@ -1010,6 +1029,8 @@ class TestProviderNotInstalled:
         ("model", "expected"),
         [
             ("openai:gpt-4o", "openextract[openai]"),
+            ("openai-chat:gpt-4o", "openextract[openai]"),
+            ("openai-responses:gpt-5.6-luna", "openextract[openai]"),
             ("anthropic:claude-sonnet-4-20250514", "openextract[anthropic]"),
             ("google-gla:gemini-2.5-flash", "openextract[google]"),
             ("google-vertex:gemini-2.5-pro", "openextract[google]"),


### PR DESCRIPTION
## Summary

- route concise `openai:<model>` identifiers through PydanticAI's OpenAI Responses provider
- preserve explicit `openai-responses:` and `openai-chat:` endpoint selection
- keep provider-install hints correct for all three OpenAI prefixes
- document the default in the README, examples, and Unreleased changelog

## Why

`gpt-5.6-luna` rejects structured function-tool extraction through Chat Completions when reasoning is enabled. Users currently have to discover and supply `openai-responses:gpt-5.6-luna` themselves. OpenExtract can make the compatible endpoint the default while retaining an explicit Chat Completions escape hatch.

## Developer impact

Existing calls such as:

```python
extract(..., model="openai:gpt-5.6-luna")
```

now use the Responses API automatically. Callers that specifically require Chat Completions can use `openai-chat:<model>`.

## Verification

- `uv run pytest --cov=openextract --cov-report=term-missing` — 266 passed, 5 skipped, 100% coverage
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- live public-PDF extraction with `openai:gpt-5.6-luna` — succeeded without the explicit Responses prefix