### PR TITLE
Reduce cold-start and provider error-classification overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ timing when that is known.
 - Python API calls no longer load `.env` into process-wide state. The CLI and
   bundled examples continue to load `.env` explicitly.
 - Examples run as `python -m examples.<module>` without mutating `sys.path`.
+- Package import defers Pydantic AI runtime modules, and model-error
+  classification inspects the raised exception's MRO without importing
+  unrelated provider SDKs.
 
 ### Security
 - Paths, URLs, bytes, file-like objects, stdin, and batch inputs now fail before

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -24,14 +24,32 @@ It needs no API keys and makes no network calls — it stubs dummy provider
 credentials and mocks the LLM call. Results are printed to stdout and the
 script exits `0`.
 
+For the startup and first-error measurements only:
+
+```bash
+uv run python scripts/bench.py --startup-only
+```
+
+To compare a base install with the full provider development environment
+without changing the repository's normal virtual environment:
+
+```bash
+uv run --isolated --no-dev --locked python scripts/bench.py --startup-only
+uv run python scripts/bench.py --startup-only
+```
+
 ## What it measures
 
 Most rows report `median`, `p95`, and `best` over `n` iterations (after a
-warmup), so both typical and tail cost are visible. The `[import]` row instead
-reports `median`, `best`, and `worst` over a fixed 5 runs:
+warmup), so both typical and tail cost are visible. Startup rows instead report
+`median`, `best`, and `worst` over five fresh subprocesses:
 
-- **`[import]`** — cold-start cost of `import openextract`, measured in a fresh
-  subprocess (5 runs).
+- **`[environment]`** — revision, Python, platform, and installed provider SDK
+  versions needed to interpret or reproduce a result.
+- **`[import]`** — cold `import openextract` latency and maximum resident set
+  size (RSS).
+- **`[model error]`** — first provider-neutral error classification latency,
+  RSS growth, and any provider modules imported by classification.
 - **`[_get_media]`** — resolving an `input_file` to `(bytes, media_type)` for a
   small text file, a ~50 KB PDF, a ~5 MB PDF, and raw `bytes` input.
 - **`[_get_media_type]`** — `mimetypes.guess_type` on a filename.
@@ -50,12 +68,43 @@ reports `median`, `best`, and `worst` over a fixed 5 runs:
 - **Cross-machine or absolute performance.** Numbers reflect the specific
   machine, Python build, and system load at the moment of the run.
 
+## Issue #165 before/after record
+
+Measurements below were captured on 2026-08-03 with CPython 3.12.9 on Apple
+silicon/macOS 26.5.1. They are medians of fresh subprocess samples in the full
+provider development environment. The base-install result is recorded
+separately because environment composition materially affects RSS.
+
+| Profile / path | Before | After | Change |
+| --- | ---: | ---: | ---: |
+| Full-provider cold import | 262.97 ms / 71.91 MiB | 61.21 ms / 41.94 MiB | -77% latency / -42% RSS |
+| First model-error classification | 672.62 ms / +102.59 MiB | 44.58 us / +0.00 MiB | >99.99% latency reduction |
+| Base-install cold import | not recorded | 68.16 ms / 44.77 MiB | baseline established |
+
+Before the change, classifying one Pydantic AI `ModelAPIError` imported OpenAI,
+Anthropic, Google GenAI, Botocore, Cohere, Hugging Face, Groq, Mistral, and gRPC
+exception modules. After the change, the benchmark reports `none`: the
+classifier matches exact module/class signatures already present in the
+exception's MRO. Public error types and provider mappings are unchanged.
+
+These results establish investigation budgets for comparable Apple-silicon
+development runs:
+
+- cold-import median at or below 100 ms and median max RSS at or below 55 MiB,
+- first-error classification median below 1 ms, RSS growth below 1 MiB, and
+  zero newly imported provider modules.
+
+The time and RSS values are diagnostic budgets, not CI assertions or public
+performance guarantees. The zero-provider-import invariant is deterministic
+and is enforced by the test suite.
+
 ## When maintainers should run it
 
 Run it **before and after** a change that touches the local hot path, and
 compare the two runs on the **same machine**:
 
 - changes to `import openextract` or module-level import work,
+- provider exception mapping or optional-provider loading,
 - `_get_media` / media handling,
 - `_build_agent` / agent construction,
 - `extract` / `extract_many` dispatch and concurrency.

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -1,4 +1,4 @@
-"""Microbenchmarks for openextract local hotspots.
+"""Offline benchmarks for openextract startup and local hotspots.
 
 We don't (and can't) benchmark the LLM round-trip itself — that's network +
 inference and dwarfs everything else. What we *can* measure is the local CPU
@@ -9,7 +9,10 @@ construction, and extraction dispatch. Anything we shave here compounds across
 
 from __future__ import annotations
 
+import argparse
+import json
 import os
+import platform
 import statistics
 import subprocess
 import sys
@@ -25,6 +28,93 @@ from pydantic import BaseModel
 os.environ.setdefault("OPENAI_API_KEY", "sk-bench-dummy")
 os.environ.setdefault("OLLAMA_BASE_URL", "http://localhost:11434/v1")
 
+_COLD_RUNS = 5
+_PROVIDER_DISTRIBUTIONS = (
+    "openai",
+    "anthropic",
+    "google-genai",
+    "botocore",
+    "cohere",
+    "huggingface-hub",
+    "groq",
+    "mistralai",
+    "grpcio",
+)
+_COLD_IMPORT_CHILD = """
+import json
+import sys
+import time
+
+try:
+    import resource
+except ImportError:
+    resource = None
+
+start = time.perf_counter()
+import openextract
+elapsed = time.perf_counter() - start
+if resource is None:
+    max_rss_bytes = None
+else:
+    max_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    max_rss_bytes = max_rss if sys.platform == "darwin" else max_rss * 1024
+print(json.dumps({"elapsed": elapsed, "max_rss_bytes": max_rss_bytes}))
+"""
+_MODEL_ERROR_CHILD = """
+import json
+import sys
+import time
+
+try:
+    import resource
+except ImportError:
+    resource = None
+
+from pydantic_ai.exceptions import ModelAPIError
+from openextract._extract import _map_exception
+
+provider_prefixes = (
+    "openai",
+    "anthropic",
+    "google.genai",
+    "botocore",
+    "cohere",
+    "huggingface_hub",
+    "groq",
+    "mistralai",
+    "grpc",
+)
+modules_before = set(sys.modules)
+rss_before = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss if resource else None
+start = time.perf_counter()
+mapped = _map_exception(ModelAPIError(model_name="openai:gpt-5", message="benchmark failure"))
+elapsed = time.perf_counter() - start
+rss_after = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss if resource else None
+rss_scale = 1 if sys.platform == "darwin" else 1024
+new_provider_modules = sorted(
+    module_name
+    for module_name in set(sys.modules) - modules_before
+    if any(
+        module_name == prefix or module_name.startswith(f"{prefix}.")
+        for prefix in provider_prefixes
+    )
+)
+print(
+    json.dumps(
+        {
+            "elapsed": elapsed,
+            "rss_delta_bytes": (
+                max(0, rss_after - rss_before) * rss_scale
+                if rss_before is not None and rss_after is not None
+                else None
+            ),
+            "mapped_type": type(mapped).__name__,
+            "new_provider_modules": new_provider_modules,
+        }
+    )
+)
+"""
+
 
 class _Person(BaseModel):
     name: str
@@ -37,6 +127,57 @@ def _fmt(seconds: float) -> str:
     if seconds >= 1e-3:
         return f"{seconds * 1000:8.3f} ms"
     return f"{seconds * 1e6:8.2f} us"
+
+
+def _fmt_bytes(size: float) -> str:
+    return f"{size / (1024 * 1024):.2f} MiB"
+
+
+def _run_child(code: str) -> dict:
+    child_env = os.environ.copy()
+    child_env["PYTHONDONTWRITEBYTECODE"] = "1"
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        env=child_env,
+        text=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def bench_environment() -> None:
+    from importlib import metadata
+
+    installed_providers = []
+    for distribution in _PROVIDER_DISTRIBUTIONS:
+        try:
+            version = metadata.version(distribution)
+        except metadata.PackageNotFoundError:
+            continue
+        installed_providers.append(f"{distribution}=={version}")
+
+    if len(installed_providers) == len(_PROVIDER_DISTRIBUTIONS):
+        profile = "full-provider development environment"
+    elif installed_providers:
+        profile = "partial-provider environment"
+    else:
+        profile = "base environment"
+
+    revision = subprocess.run(
+        ["git", "rev-parse", "--short", "HEAD"],
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    print("[environment]")
+    print(f"  profile={profile}")
+    print(f"  revision={revision or 'unknown'}")
+    print(f"  python={platform.python_implementation()} {platform.python_version()}")
+    print(f"  platform={platform.platform()}")
+    print(
+        "  providers="
+        + (", ".join(installed_providers) if installed_providers else "none installed")
+    )
 
 
 def _bench(label: str, fn, *, iters: int, warmup: int = 1) -> None:
@@ -55,20 +196,48 @@ def _bench(label: str, fn, *, iters: int, warmup: int = 1) -> None:
 
 
 def bench_import_cost() -> None:
-    print("\n[import] cold-start cost of `import openextract` (subprocess)")
-    timings = []
-    for _ in range(5):
-        t0 = time.perf_counter()
-        subprocess.run(
-            [sys.executable, "-c", "import openextract"],
-            check=True,
-            capture_output=True,
-        )
-        timings.append(time.perf_counter() - t0)
+    print("\n[import] cold `import openextract` in fresh subprocesses")
+    samples = [_run_child(_COLD_IMPORT_CHILD) for _ in range(_COLD_RUNS)]
+    timings = [sample["elapsed"] for sample in samples]
+    max_rss = [sample["max_rss_bytes"] for sample in samples if sample["max_rss_bytes"]]
     timings.sort()
     print(
-        f"  median={_fmt(statistics.median(timings))}  "
+        f"  latency: median={_fmt(statistics.median(timings))}  "
         f"best={_fmt(timings[0])}  worst={_fmt(timings[-1])}"
+    )
+    if max_rss:
+        print(
+            f"  max RSS: median={_fmt_bytes(statistics.median(max_rss))}  "
+            f"best={_fmt_bytes(min(max_rss))}  worst={_fmt_bytes(max(max_rss))}"
+        )
+    else:
+        print("  max RSS: unavailable on this platform")
+
+
+def bench_model_error_classification() -> None:
+    print("\n[model error] first provider-neutral error classification")
+    samples = [_run_child(_MODEL_ERROR_CHILD) for _ in range(_COLD_RUNS)]
+    timings = sorted(sample["elapsed"] for sample in samples)
+    rss_deltas = [
+        sample["rss_delta_bytes"] for sample in samples if sample["rss_delta_bytes"] is not None
+    ]
+    mapped_types = {sample["mapped_type"] for sample in samples}
+    new_provider_modules = sorted(
+        {module_name for sample in samples for module_name in sample["new_provider_modules"]}
+    )
+    if mapped_types != {"ModelError"}:
+        raise RuntimeError(f"Unexpected mapped exception types: {sorted(mapped_types)}")
+    print(
+        f"  latency: median={_fmt(statistics.median(timings))}  "
+        f"best={_fmt(timings[0])}  worst={_fmt(timings[-1])}"
+    )
+    if rss_deltas:
+        print(f"  max RSS delta: median={_fmt_bytes(statistics.median(rss_deltas))}")
+    else:
+        print("  max RSS delta: unavailable on this platform")
+    print(
+        "  newly imported provider modules: "
+        + (", ".join(new_provider_modules) if new_provider_modules else "none")
     )
 
 
@@ -155,8 +324,24 @@ def bench_extract_end_to_end(tmp: Path) -> None:
         )
 
 
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--startup-only",
+        action="store_true",
+        help="run only environment, cold-import, and first-error benchmarks",
+    )
+    return parser.parse_args()
+
+
 def main() -> int:
+    args = _parse_args()
+    bench_environment()
     bench_import_cost()
+    bench_model_error_classification()
+
+    if args.startup_only:
+        return 0
 
     with tempfile.TemporaryDirectory() as td:
         tmp = Path(td)

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -1,7 +1,6 @@
 """Core extraction functionality."""
 
 import asyncio
-import importlib
 import ipaddress
 import math
 import mimetypes
@@ -14,13 +13,22 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from email.utils import parsedate_to_datetime
 from pathlib import Path
-from typing import BinaryIO, TypeVar, cast
+from typing import TYPE_CHECKING, BinaryIO, TypeVar, cast
 from urllib.parse import urlparse
 
 import httpx
 from pydantic import BaseModel, ValidationError
-from pydantic_ai import Agent, BinaryContent
-from pydantic_ai.output import NativeOutput
+
+if TYPE_CHECKING:
+    from pydantic_ai import Agent
+else:
+
+    def Agent(*args, **kwargs):
+        """Construct a Pydantic AI agent without loading it at package import time."""
+        from pydantic_ai import Agent as PydanticAgent
+
+        return PydanticAgent(*args, **kwargs)
+
 
 from .exceptions import (
     ExtractionError,
@@ -84,21 +92,24 @@ _PERMANENT_ERROR_NAMES = (
     "accessdenied",
 )
 
-# (module, attribute) pairs for provider/model error base classes we want to
-# classify as ``ModelError``. ``openai.APIError`` also covers OpenRouter and
+# Exact (module, class) signatures for provider/model error bases we classify
+# as ``ModelError``. The classifier checks the exception's existing MRO instead
+# of importing provider SDKs. ``openai.APIError`` also covers OpenRouter and
 # Cerebras since both go through the openai SDK.
-_PROVIDER_ERROR_PATHS: tuple[tuple[str, str], ...] = (
-    ("pydantic_ai.exceptions", "ModelAPIError"),
-    ("openai", "APIError"),
-    ("anthropic", "APIError"),
-    ("google.genai.errors", "APIError"),
-    ("botocore.exceptions", "ClientError"),
-    ("botocore.exceptions", "BotoCoreError"),
-    ("cohere.core.api_error", "ApiError"),
-    ("huggingface_hub.errors", "HfHubHTTPError"),
-    ("groq", "APIError"),
-    ("mistralai.client.errors.mistralerror", "MistralError"),
-    ("grpc", "RpcError"),  # xAI SDK uses gRPC; pydantic-ai may surface this directly
+_MODEL_ERROR_SIGNATURES = frozenset(
+    {
+        ("pydantic_ai.exceptions", "ModelAPIError"),
+        ("openai", "APIError"),
+        ("anthropic", "APIError"),
+        ("google.genai.errors", "APIError"),
+        ("botocore.exceptions", "ClientError"),
+        ("botocore.exceptions", "BotoCoreError"),
+        ("cohere.core.api_error", "ApiError"),
+        ("huggingface_hub.errors", "HfHubHTTPError"),
+        ("groq", "APIError"),
+        ("mistralai.client.errors.mistralerror", "MistralError"),
+        ("grpc", "RpcError"),  # xAI SDK uses gRPC; pydantic-ai may surface this directly
+    }
 )
 
 # pydantic-ai model-id prefix -> the openextract optional-dependency extra that
@@ -124,33 +135,17 @@ _PROVIDER_EXTRAS: dict[str, str] = {
 }
 
 
-def _collect_model_error_types() -> tuple[type[BaseException], ...]:
-    """Resolve ``_PROVIDER_ERROR_PATHS`` to importable exception classes.
+def _is_model_exception(exc: BaseException) -> bool:
+    """Return whether an exception inherits from a supported model error base.
 
-    Each import is guarded so a missing optional provider does not break the
-    package. The returned tuple is suitable for use with ``isinstance``.
-
-    Cached after the first call. Deferred (rather than run at module import)
-    because importing every provider SDK eagerly added ~2 s to cold start —
-    ``google.genai`` alone is over a second — and is wasted work unless we
-    actually need to classify an exception.
+    Provider SDKs have already created the exception by the time this runs, so
+    their classes are present in its MRO. Comparing exact module/class
+    signatures preserves subclass handling without importing unrelated SDKs.
     """
-    global _MODEL_ERROR_TYPES
-    if _MODEL_ERROR_TYPES is not None:
-        return _MODEL_ERROR_TYPES
-
-    error_types: list[type[BaseException]] = []
-    for module_name, attr in _PROVIDER_ERROR_PATHS:
-        try:
-            module = importlib.import_module(module_name)
-        except ImportError:  # pragma: no cover - all provider extras are installed
-            continue
-        error_types.append(getattr(module, attr))
-    _MODEL_ERROR_TYPES = tuple(error_types)
-    return _MODEL_ERROR_TYPES
-
-
-_MODEL_ERROR_TYPES: tuple[type[BaseException], ...] | None = None
+    return any(
+        (error_type.__module__, error_type.__name__) in _MODEL_ERROR_SIGNATURES
+        for error_type in type(exc).__mro__
+    )
 
 
 @dataclass(frozen=True)
@@ -640,10 +635,15 @@ def _build_agent(schema: type[T], model: str, instructions: str | None) -> Agent
     :class:`ProviderNotInstalledError`.
     """
     try:
+        output_type = schema
+        if model.startswith("ollama"):
+            from pydantic_ai.output import NativeOutput
+
+            output_type = NativeOutput(schema)
         return Agent(
             _route_model(model),
             instructions=instructions,
-            output_type=NativeOutput(schema) if model.startswith("ollama") else schema,
+            output_type=output_type,
         )
     except ImportError as exc:
         raise ProviderNotInstalledError(
@@ -655,6 +655,8 @@ def _build_agent(schema: type[T], model: str, instructions: str | None) -> Agent
 
 def _build_run_inputs(file_bytes: bytes, file_type: str) -> list:
     """Build the prompt inputs passed to the agent run."""
+    from pydantic_ai import BinaryContent
+
     return [
         "Extract the requested information from this document.",
         BinaryContent(data=file_bytes, media_type=file_type),
@@ -795,7 +797,7 @@ def _map_exception(exc: BaseException) -> ExtractionError:
         return UrlFetchError(f"Failed to fetch URL: {exc}")
     if isinstance(exc, ValidationError):
         return SchemaValidationError(f"Model output did not match schema: {exc}")
-    if isinstance(exc, _collect_model_error_types()):
+    if _is_model_exception(exc):
         status_code = _model_status_code(exc)
         return ModelError(
             f"Model API error: {exc}",

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -5,6 +5,8 @@ import io
 import ipaddress
 import os
 import socket
+import subprocess
+import sys
 import threading
 import time
 from pathlib import Path
@@ -15,6 +17,7 @@ import pytest
 from pydantic import BaseModel, ValidationError
 from pydantic_ai import BinaryContent
 
+import openextract._extract as extract_module
 from openextract import (
     ExtractionError,
     InputTooLargeError,
@@ -895,6 +898,59 @@ def _make_agent_mock(mocker, output=None, run_sync_side_effect=None, usage=None)
     return agent_cls, agent_instance
 
 
+def test_model_error_classification_does_not_import_provider_sdks():
+    from pydantic_ai.exceptions import ModelAPIError
+
+    provider_prefixes = (
+        "openai",
+        "anthropic",
+        "google.genai",
+        "botocore",
+        "cohere",
+        "huggingface_hub",
+        "groq",
+        "mistralai",
+        "grpc",
+    )
+    modules_before = set(sys.modules)
+
+    mapped = _map_exception(ModelAPIError(model_name="openai:gpt-5", message="failed"))
+
+    newly_loaded_provider_modules = {
+        module_name
+        for module_name in set(sys.modules) - modules_before
+        if any(
+            module_name == prefix or module_name.startswith(f"{prefix}.")
+            for prefix in provider_prefixes
+        )
+    }
+    assert isinstance(mapped, ModelError)
+    assert newly_loaded_provider_modules == set()
+
+
+def test_package_import_defers_pydantic_ai_runtime():
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; import openextract; assert 'pydantic_ai' not in sys.modules",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_lazy_agent_proxy_constructs_pydantic_agent(mocker):
+    expected = MagicMock()
+    pydantic_agent = mocker.patch("pydantic_ai.Agent", return_value=expected)
+
+    result = extract_module.Agent("openai:gpt-5", output_type=_Person)
+
+    assert result is expected
+    pydantic_agent.assert_called_once_with("openai:gpt-5", output_type=_Person)
+
+
 class TestExtract:
     def test_oversized_input_fails_before_agent_build(self, mocker):
         agent = mocker.patch("openextract._extract.Agent")
@@ -1051,6 +1107,10 @@ class TestExtract:
                 "anthropic:claude-sonnet-4",
             ),
             (
+                lambda msg: _make_bare_provider_error("google.genai.errors", "APIError", msg),
+                "google-gla:gemini-2.5-pro",
+            ),
+            (
                 lambda msg: _make_bedrock_error(msg),
                 "bedrock:anthropic.claude-sonnet-4-20250514-v1:0",
             ),
@@ -1072,6 +1132,7 @@ class TestExtract:
             "pydantic_ai_ModelHTTPError",
             "openai_APIError",
             "anthropic_APIError",
+            "google_APIError",
             "bedrock_ClientError",
             "cohere_ApiError",
             "huggingface_HfHubHTTPError",


### PR DESCRIPTION
## Summary

- classify provider failures from exact module/class signatures already present in the exception MRO
- lazy-load Pydantic AI runtime modules when an agent or binary input is first constructed
- extend the offline benchmark with environment metadata, cold-import latency/RSS, first-error latency/RSS, provider-import detection, and a startup-only mode
- document before/after results and evidence-based investigation budgets

## Why

The first model-error classification imported every installed provider SDK so it could build an `isinstance` tuple. A single Pydantic AI error therefore loaded unrelated SDKs, adding hundreds of milliseconds and roughly 100 MiB of peak RSS. Importing `openextract` also eagerly loaded Pydantic AI implementation modules even when callers only inspected the package.

The raised provider exception already contains its real base classes in its MRO, so the classifier can match the supported base signatures without importing anything else.

## Impact

Provider error mapping and the public exception hierarchy are unchanged. Regression coverage includes Pydantic AI, OpenAI, Anthropic, Google, Bedrock, Cohere, Hugging Face, Groq, Mistral, and xAI errors.

Full-provider measurements on CPython 3.12.9 / Apple silicon:

| Path | Before | After |
| --- | ---: | ---: |
| Cold import | 262.97 ms / 71.91 MiB | 61.21 ms / 41.94 MiB |
| First model-error classification | 672.62 ms / +102.59 MiB | 44.58 μs / +0.00 MiB |

An isolated base install measured 68.16 ms / 44.77 MiB. The first-error benchmark reports zero newly imported provider modules.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest -q --cov=openextract --cov-report=term-missing --cov-fail-under=0`
- `uv run coverage report --fail-under=100`
- `uv run python scripts/check_api_reference.py`
- `uv run python scripts/bench.py`
- `uv run --isolated --no-dev --locked python scripts/bench.py --startup-only`

Closes #165