### PR TITLE
Add reusable Extractor and AsyncExtractor sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ timing when that is known.
 ## [Unreleased]
 
 ### Added
+- Reusable `Extractor` and `AsyncExtractor` sessions with deterministic agent
+  and HTTP-client cleanup, configured Pydantic AI model or agent injection,
+  model settings/timeouts/instrumentation, and typed `RetryPolicy` support.
 - `InputTooLargeError`, a 50 MiB default per-input cap, the
   `OPENEXTRACT_MAX_INPUT_BYTES` environment variable, `max_input_bytes` on all
   extraction APIs, and `--max-input-bytes` on the CLI.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,70 @@ print(result.language)
 
 `result` is a fully-validated `PdfInfo` instance &mdash; not a dict, not a string.
 
+## Reusable sessions
+
+For repeated extractions with the same schema and model, use `Extractor` or
+`AsyncExtractor`. A session constructs one Pydantic AI agent, reuses its
+provider and input-fetch HTTP clients, and closes them deterministically.
+
+```python
+from openextract import Extractor, RetryPolicy
+
+with Extractor(
+    schema=PdfInfo,
+    model="openai:gpt-5",
+    instructions="Extract the summary and primary language.",
+    model_settings={"temperature": 0},
+    timeout=30,
+    retry_policy=RetryPolicy(max_retries=3),
+) as extractor:
+    first = extractor.extract("./reports/q3.pdf")
+    second, usage = extractor.extract_with_usage("./reports/q4.pdf")
+```
+
+The async session is bound to the event loop that enters it and supports
+concurrent calls on that loop:
+
+```python
+import asyncio
+from openextract import AsyncExtractor
+
+async def main() -> None:
+    async with AsyncExtractor(PdfInfo, "openai:gpt-5") as extractor:
+        q3, q4 = await asyncio.gather(
+            extractor.extract("./reports/q3.pdf"),
+            extractor.extract("./reports/q4.pdf"),
+        )
+
+asyncio.run(main())
+```
+
+`model` may also be a configured `pydantic_ai.models.Model`, preserving custom
+providers, endpoints, credentials, and model defaults without string-prefix
+routing. For advanced dependency injection, pass a fully configured
+`pydantic_ai.Agent` as `agent=` instead of `model=`. Openextract revalidates the
+agent output against `schema`; agent instructions, model settings, timeout, and
+instrumentation must be configured on the injected agent itself.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+from openextract import Extractor
+
+test_agent = Agent(
+    TestModel(custom_output_args={"summary": "Test", "language": "en"}),
+    output_type=PdfInfo,
+)
+with Extractor(PdfInfo, agent=test_agent) as extractor:
+    assert extractor.extract(b"fixture", media_type="text/plain").language == "en"
+```
+
+`Extractor` is thread-bound and not thread-safe; use one per thread.
+`AsyncExtractor` must be entered and used on one event loop, though calls may
+overlap within that loop. Both classes must be used as context managers (or
+closed explicitly with `close()` / `aclose()`). Set `instrument=True` to enable
+Pydantic AI instrumentation, or pass an `InstrumentationSettings` instance.
+
 ## Usage
 
 ### Local files

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -11,6 +11,31 @@ in the same change as any public signature.
 
 ## Extraction
 
+### `Extractor(schema, model=None, instructions=None, *, agent=None, model_settings=None, timeout=None, instrument=False, retry_policy=None, max_input_bytes=None, url_timeout=None)`
+
+Reusable synchronous extraction session. Enter it with `with`; then call
+`extract(input_file, *, media_type=None)` or
+`extract_with_usage(input_file, *, media_type=None)`. The agent, model provider
+client, and URL-fetch client are constructed once and closed on context exit.
+
+`model` accepts either a known model string or a configured
+`pydantic_ai.models.Model`. As an advanced alternative, `agent` accepts a fully
+configured Pydantic AI `Agent`; it is mutually exclusive with `model`, and its
+output is revalidated against `schema`.
+
+### `AsyncExtractor(schema, model=None, instructions=None, *, agent=None, model_settings=None, timeout=None, instrument=False, retry_policy=None, max_input_bytes=None, url_timeout=None)`
+
+Async session counterpart. Enter it with `async with`; then await `extract` or
+`extract_with_usage`. It shares one async HTTP client and one agent across
+calls, including concurrent calls made on the entering event loop. Close it
+manually with `aclose()` only when a context manager is impractical.
+
+### `RetryPolicy(max_retries=0, backoff=1.0, max_backoff=60.0)`
+
+Frozen session retry configuration. Only transient `ModelError` failures are
+retried. The backoff and bounded provider `Retry-After` behavior match the
+one-shot function arguments.
+
 ### `extract(schema, model, input_file, instructions=None, *, media_type=None, max_input_bytes=None, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
 
 Extract one input synchronously and return an instance of `schema`.
@@ -57,7 +82,7 @@ yielded in the result position and streaming continues.
 | Argument | Type | Description |
 | --- | --- | --- |
 | `schema` | `type[BaseModel]` | Pydantic model class describing the desired output. |
-| `model` | `str` | `pydantic-ai` model identifier such as `"xai:grok-4.3"`. |
+| `model` | `str \| Model` | `pydantic-ai` model identifier or configured model instance. |
 | `input_file` | `str \| bytes \| BinaryIO` | Local path, HTTP(S) URL, bytes, or binary file-like object. |
 | `instructions` | `str \| None` | Optional model guidance. |
 | `media_type` | `str \| None` | Required for bytes and file-like inputs; overrides inference for paths and URLs. |
@@ -89,3 +114,14 @@ Batch functions also accept:
 The Python library reads provider configuration from the existing process
 environment and does not load `.env` files. The `openextract` CLI and bundled
 examples load `.env` explicitly as an application-level convenience.
+
+Session `model_settings` are passed directly to Pydantic AI using its typed
+`ModelSettings` contract. `timeout` is an explicit shortcut for the model
+request timeout and overrides a `timeout` entry in `model_settings`.
+`url_timeout` separately controls URL input fetching. `instrument=True` enables
+Pydantic AI instrumentation; an `InstrumentationSettings` instance provides
+fine-grained control.
+
+`Extractor` is bound to the thread that enters it and is not thread-safe.
+`AsyncExtractor` is bound to one event loop; concurrent calls within that loop
+are supported. Neither session can be reopened after it is closed.

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,6 +49,7 @@ uv run python -m examples.run_all
 | `async/` | `async_extract.py` | Anthropic | `extract_async()` |
 | `advanced/` | `extract_with_usage.py` | xAI | `extract_with_usage()` and token counts |
 | `advanced/` | `retry_extract.py` | OpenAI | `max_retries` / `retry_backoff` |
+| `advanced/` | `reusable_sessions.py` | TestModel | Sync/async sessions and dependency-injected agents |
 | `advanced/` | `error_handling.py` | — | Catching `UrlFetchError` (no model call) |
 | `audio/` | `meeting_notes.py` | xAI | Audio → structured meeting notes (bring your own file) |
 | `cli/` | `schemas.py` | — | Pydantic models for CLI `--schema` |

--- a/examples/advanced/reusable_sessions.py
+++ b/examples/advanced/reusable_sessions.py
@@ -1,0 +1,41 @@
+"""Reusable sync/async sessions with a dependency-injected test agent."""
+
+from __future__ import annotations
+
+import asyncio
+
+from pydantic import BaseModel
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+
+from openextract import AsyncExtractor, Extractor
+
+
+class Contact(BaseModel):
+    name: str
+    email: str
+
+
+def test_agent() -> Agent:
+    """Build a deterministic agent; production code can inject a configured provider agent."""
+    model = TestModel(custom_output_args={"name": "Ada Lovelace", "email": "ada@example.com"})
+    return Agent(model, output_type=Contact)
+
+
+def sync_example() -> Contact:
+    with Extractor(Contact, agent=test_agent()) as extractor:
+        return extractor.extract(b"Ada <ada@example.com>", media_type="text/plain")
+
+
+async def async_example() -> Contact:
+    async with AsyncExtractor(Contact, agent=test_agent()) as extractor:
+        return await extractor.extract(b"Ada <ada@example.com>", media_type="text/plain")
+
+
+def main() -> None:
+    print(sync_example().model_dump_json(indent=2))
+    print(asyncio.run(async_example()).model_dump_json(indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/run_all.py
+++ b/examples/run_all.py
@@ -30,6 +30,7 @@ API_EXAMPLES: list[tuple[str, list[str]]] = [
 
 NO_API_EXAMPLES: list[str] = [
     "examples.advanced.error_handling",
+    "examples.advanced.reusable_sessions",
 ]
 
 

--- a/src/openextract/__init__.py
+++ b/src/openextract/__init__.py
@@ -3,6 +3,9 @@ openextract - Extract structured data from documents, images, audio, and video u
 """
 
 from ._extract import (
+    AsyncExtractor,
+    Extractor,
+    RetryPolicy,
     Usage,
     extract,
     extract_async,
@@ -22,6 +25,9 @@ from .exceptions import (
 )
 
 __all__ = [
+    "Extractor",
+    "AsyncExtractor",
+    "RetryPolicy",
     "extract",
     "extract_async",
     "extract_many",

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -1,5 +1,7 @@
 """Core extraction functionality."""
 
+from __future__ import annotations
+
 import asyncio
 import ipaddress
 import math
@@ -7,6 +9,7 @@ import mimetypes
 import os
 import random
 import socket
+import threading
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Iterator, Mapping
 from contextlib import contextmanager
@@ -20,7 +23,10 @@ import httpx
 from pydantic import BaseModel, ValidationError
 
 if TYPE_CHECKING:
-    from pydantic_ai import Agent
+    from pydantic_ai import Agent as PydanticAgent
+    from pydantic_ai.models import Model
+    from pydantic_ai.models.instrumented import InstrumentationSettings
+    from pydantic_ai.settings import ModelSettings
 else:
 
     def Agent(*args, **kwargs):
@@ -155,6 +161,18 @@ class Usage:
     input_tokens: int
     output_tokens: int
     total_tokens: int
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    """Retry configuration shared by every call made through an extractor session."""
+
+    max_retries: int = 0
+    backoff: float = 1.0
+    max_backoff: float = _DEFAULT_RETRY_MAX_BACKOFF
+
+    def __post_init__(self) -> None:
+        _validate_retry_options(self.max_retries, self.backoff, self.max_backoff)
 
 
 def _get_media_type(file_path: str) -> str:
@@ -494,10 +512,22 @@ def _media_from_content(
     return content, media_type
 
 
-def _read_from_path(file_path: str, *, max_input_bytes: int) -> tuple[bytes, str]:
+def _read_from_path(
+    file_path: str,
+    *,
+    max_input_bytes: int,
+    client: httpx.Client | None = None,
+) -> tuple[bytes, str]:
     """Read bytes from a local path or http(s) URL; return (bytes, media_type)."""
     if file_path.startswith(_URL_PREFIXES):
-        content, headers = _read_url(file_path, limit=max_input_bytes)
+        if client is None:
+            content, headers = _read_url(file_path, limit=max_input_bytes)
+        else:
+            content, headers = _read_url_with_client(
+                file_path,
+                client,
+                limit=max_input_bytes,
+            )
         return _media_from_content(file_path, content, headers)
 
     path = Path(file_path)
@@ -548,6 +578,7 @@ def _get_media(
     media_type: str | None = None,
     *,
     max_input_bytes: int | None = None,
+    client: httpx.Client | None = None,
 ) -> tuple[bytes, str]:
     """Resolve ``input_file`` to ``(bytes, media_type)``.
 
@@ -557,7 +588,11 @@ def _get_media(
     """
     limit = _resolve_max_input_bytes(max_input_bytes)
     if isinstance(input_file, str):
-        file_bytes, resolved_type = _read_from_path(input_file, max_input_bytes=limit)
+        file_bytes, resolved_type = _read_from_path(
+            input_file,
+            max_input_bytes=limit,
+            client=client,
+        )
         return file_bytes, media_type or resolved_type
 
     if isinstance(input_file, bytes):
@@ -627,7 +662,37 @@ def _route_model(model: str) -> str:
     return model
 
 
-def _build_agent(schema: type[T], model: str, instructions: str | None) -> Agent:
+def _instrumentation_capabilities(
+    instrument: bool | InstrumentationSettings,
+) -> tuple[list[object], dict[str, object]]:
+    """Return version-compatible Pydantic AI instrumentation arguments."""
+    if instrument is False:
+        return [], {}
+
+    from pydantic_ai.models.instrumented import InstrumentationSettings
+
+    if instrument is True:
+        settings = InstrumentationSettings()
+    elif isinstance(instrument, InstrumentationSettings):
+        settings = instrument
+    else:
+        raise TypeError("instrument must be a bool or InstrumentationSettings instance.")
+
+    try:
+        from pydantic_ai.capabilities import Instrumentation
+    except ImportError:  # pragma: no cover - compatibility with older pydantic-ai
+        return [], {"instrument": settings}
+    return [Instrumentation(settings)], {}
+
+
+def _build_agent(
+    schema: type[T],
+    model: str | Model,
+    instructions: str | None,
+    *,
+    model_settings: ModelSettings | None = None,
+    instrument: bool | InstrumentationSettings = False,
+) -> PydanticAgent:
     """Construct the pydantic_ai Agent, handling the ollama output-type quirk.
 
     A missing provider SDK surfaces here as ``ImportError`` (pydantic-ai infers
@@ -636,21 +701,34 @@ def _build_agent(schema: type[T], model: str, instructions: str | None) -> Agent
     """
     try:
         output_type = schema
-        if model.startswith("ollama"):
+        if isinstance(model, str) and model.startswith("ollama"):
             from pydantic_ai.output import NativeOutput
 
             output_type = NativeOutput(schema)
+        capabilities, compatibility_kwargs = _instrumentation_capabilities(instrument)
+        routed_model = _route_model(model) if isinstance(model, str) else model
+        agent_kwargs: dict[str, object] = {
+            "instructions": instructions,
+            "output_type": output_type,
+            "model_settings": model_settings,
+            **compatibility_kwargs,
+        }
+        if capabilities:
+            agent_kwargs["capabilities"] = capabilities
         return Agent(
-            _route_model(model),
-            instructions=instructions,
-            output_type=output_type,
+            routed_model,
+            **agent_kwargs,
         )
     except ImportError as exc:
-        raise ProviderNotInstalledError(
-            f"Model {model!r} needs a provider SDK that is not installed. "
-            f"Install it with: {_install_hint(model)} "
-            f"(or 'pip install openextract[all]'). Original error: {exc}"
-        ) from exc
+        if isinstance(model, str):
+            message = (
+                f"Model {model!r} needs a provider SDK that is not installed. "
+                f"Install it with: {_install_hint(model)} "
+                f"(or 'pip install openextract[all]'). Original error: {exc}"
+            )
+        else:
+            message = f"The configured model needs a provider SDK that is not installed: {exc}"
+        raise ProviderNotInstalledError(message) from exc
 
 
 def _build_run_inputs(file_bytes: bytes, file_type: str) -> list:
@@ -827,7 +905,12 @@ def _extraction_errors() -> Iterator[None]:
 
 def _usage_from_result(result) -> Usage:
     """Build a ``Usage`` from a pydantic-ai run result."""
-    raw = result.usage()
+    usage_descriptor = getattr(type(result), "usage", None)
+    raw = (
+        result.usage
+        if usage_descriptor is not None and not callable(usage_descriptor)
+        else result.usage()
+    )
     return Usage(
         input_tokens=getattr(raw, "input_tokens", 0) or 0,
         output_tokens=getattr(raw, "output_tokens", 0) or 0,
@@ -837,12 +920,12 @@ def _usage_from_result(result) -> Usage:
 
 def _prepare_run(
     schema: type[T],
-    model: str,
+    model: str | Model,
     input_file: str | bytes | BinaryIO,
     instructions: str | None,
     media_type: str | None,
     max_input_bytes: int,
-) -> tuple[Agent, list]:
+) -> tuple[PydanticAgent, list]:
     """Resolve the media payload and build the agent + run inputs."""
     file_bytes, file_type = _get_media(
         input_file,
@@ -855,13 +938,13 @@ def _prepare_run(
 
 async def _prepare_run_async(
     schema: type[T],
-    model: str,
+    model: str | Model,
     input_file: str | bytes | BinaryIO,
     instructions: str | None,
     media_type: str | None,
     max_input_bytes: int,
     client: httpx.AsyncClient | None = None,
-) -> tuple[Agent, list]:
+) -> tuple[PydanticAgent, list]:
     """Async media preparation plus agent construction."""
     file_bytes, file_type = await _get_media_async(
         input_file,
@@ -875,12 +958,12 @@ async def _prepare_run_async(
 
 def _prepare_extraction(
     schema: type[T],
-    model: str,
+    model: str | Model,
     input_file: str | bytes | BinaryIO,
     instructions: str | None,
     media_type: str | None,
     max_input_bytes: int,
-) -> tuple[Agent, list]:
+) -> tuple[PydanticAgent, list]:
     """Prepare one extraction while applying the public exception mapping."""
     with _extraction_errors():
         return _prepare_run(
@@ -895,13 +978,13 @@ def _prepare_extraction(
 
 async def _prepare_extraction_async(
     schema: type[T],
-    model: str,
+    model: str | Model,
     input_file: str | bytes | BinaryIO,
     instructions: str | None,
     media_type: str | None,
     max_input_bytes: int,
     client: httpx.AsyncClient | None = None,
-) -> tuple[Agent, list]:
+) -> tuple[PydanticAgent, list]:
     """Prepare one async extraction while applying public exception mapping."""
     with _extraction_errors():
         return await _prepare_run_async(
@@ -933,8 +1016,26 @@ async def _prepare_run_inputs_async(
         return _build_run_inputs(file_bytes, file_type)
 
 
+def _prepare_run_inputs_sync(
+    input_file: str | bytes | BinaryIO,
+    media_type: str | None,
+    client: httpx.Client | None = None,
+    *,
+    max_input_bytes: int,
+) -> list:
+    """Resolve one sync media input and build a prompt for retry reuse."""
+    with _extraction_errors():
+        file_bytes, file_type = _get_media(
+            input_file,
+            media_type=media_type,
+            max_input_bytes=max_input_bytes,
+            client=client,
+        )
+        return _build_run_inputs(file_bytes, file_type)
+
+
 def _run_extraction(
-    agent: Agent,
+    agent: PydanticAgent,
     inputs: list,
 ):
     """Run a prepared sync extraction and return the raw pydantic-ai result."""
@@ -943,7 +1044,7 @@ def _run_extraction(
 
 
 def _extract_once(
-    agent: Agent,
+    agent: PydanticAgent,
     inputs: list,
 ) -> T:
     """Perform a single sync extraction attempt; return the schema instance."""
@@ -951,7 +1052,7 @@ def _extract_once(
     return cast(T, result.output)
 
 
-async def _run_extraction_async(agent: Agent, inputs: list):
+async def _run_extraction_async(agent: PydanticAgent, inputs: list):
     """Run a prepared async extraction with public exception mapping."""
     with _extraction_errors():
         return await agent.run(inputs)
@@ -1047,9 +1148,392 @@ async def _run_with_retries_async[R](
             attempt += 1
 
 
+def _validate_timeout(value: object, *, name: str) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int | float)
+        or not math.isfinite(value)
+        or value <= 0
+    ):
+        raise ValueError(f"{name} must be a finite positive number of seconds.")
+    return float(value)
+
+
+def _session_model_settings(
+    model_settings: ModelSettings | None,
+    timeout: float | None,
+) -> ModelSettings | None:
+    settings = dict(model_settings) if model_settings is not None else {}
+    if timeout is not None:
+        settings["timeout"] = _validate_timeout(timeout, name="timeout")
+    return cast("ModelSettings | None", settings or None)
+
+
+class _ExtractorSession[T: BaseModel]:
+    """Configuration and output validation shared by sync and async sessions."""
+
+    def __init__(
+        self,
+        schema: type[T],
+        model: str | Model | None,
+        instructions: str | None,
+        *,
+        agent: PydanticAgent | None,
+        model_settings: ModelSettings | None,
+        timeout: float | None,
+        instrument: bool | InstrumentationSettings,
+        retry_policy: RetryPolicy | None,
+        max_input_bytes: int | None,
+        url_timeout: float | None,
+    ) -> None:
+        if agent is not None:
+            if model is not None:
+                raise ValueError("model and agent are mutually exclusive; provide exactly one.")
+            if instructions is not None or model_settings is not None or timeout is not None:
+                raise ValueError(
+                    "instructions, model_settings, and timeout must be configured "
+                    "on an injected agent."
+                )
+            if instrument is not False:
+                raise ValueError("instrument must be configured on an injected agent.")
+            configured_agent = agent
+        else:
+            if model is None:
+                raise TypeError("model is required unless agent is provided.")
+            configured_agent = _build_agent(
+                schema,
+                model,
+                instructions,
+                model_settings=_session_model_settings(model_settings, timeout),
+                instrument=instrument,
+            )
+
+        if retry_policy is None:
+            retry_policy = RetryPolicy()
+        elif not isinstance(retry_policy, RetryPolicy):
+            raise TypeError("retry_policy must be a RetryPolicy instance.")
+
+        self._schema = schema
+        self._agent = configured_agent
+        self._retry_policy = retry_policy
+        self._max_input_bytes = _resolve_max_input_bytes(max_input_bytes)
+        self._url_timeout = (
+            _url_fetch_timeout()
+            if url_timeout is None
+            else _validate_timeout(url_timeout, name="url_timeout")
+        )
+        self._entered = False
+        self._closed = False
+
+    def _validate_output(self, output: object) -> T:
+        with _extraction_errors():
+            return self._schema.model_validate(output)
+
+    def _ensure_enterable(self, class_name: str) -> None:
+        if self._closed:
+            raise RuntimeError(f"{class_name} is closed and cannot be reused.")
+        if self._entered:
+            raise RuntimeError(f"{class_name} is already entered.")
+
+    def _ensure_open(self, class_name: str) -> None:
+        if not self._entered:
+            raise RuntimeError(f"{class_name} must be used as a context manager before extraction.")
+
+
+class Extractor(_ExtractorSession[T]):
+    """Reusable synchronous extraction session.
+
+    An ``Extractor`` is bound to the thread that enters it and is not
+    thread-safe. Use one session per thread and close it deterministically with
+    a ``with`` block.
+    """
+
+    def __init__(
+        self,
+        schema: type[T],
+        model: str | Model | None = None,
+        instructions: str | None = None,
+        *,
+        agent: PydanticAgent | None = None,
+        model_settings: ModelSettings | None = None,
+        timeout: float | None = None,
+        instrument: bool | InstrumentationSettings = False,
+        retry_policy: RetryPolicy | None = None,
+        max_input_bytes: int | None = None,
+        url_timeout: float | None = None,
+    ) -> None:
+        super().__init__(
+            schema,
+            model,
+            instructions,
+            agent=agent,
+            model_settings=model_settings,
+            timeout=timeout,
+            instrument=instrument,
+            retry_policy=retry_policy,
+            max_input_bytes=max_input_bytes,
+            url_timeout=url_timeout,
+        )
+        self._client: httpx.Client | None = None
+        self._runner: asyncio.Runner | None = None
+        self._thread_id: int | None = None
+
+    def __enter__(self) -> Extractor[T]:
+        self._ensure_enterable(type(self).__name__)
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+        else:
+            raise RuntimeError(
+                "Extractor cannot be entered from a running event loop; use AsyncExtractor instead."
+            )
+
+        client = httpx.Client(follow_redirects=False, timeout=self._url_timeout)
+        # Keep the session loop private so entering an Extractor does not replace
+        # or clear the caller's process-wide current event loop.
+        runner = asyncio.Runner(loop_factory=asyncio.new_event_loop)
+        runner.__enter__()
+        try:
+            runner.run(self._agent.__aenter__())
+        except BaseException:
+            client.close()
+            runner.close()
+            raise
+
+        self._client = client
+        self._runner = runner
+        self._thread_id = threading.get_ident()
+        self._entered = True
+        return self
+
+    def __exit__(self, *exc_info: object) -> bool:
+        return self._close(exc_info)
+
+    def _close(self, exc_info: tuple[object, ...]) -> bool:
+        if not self._entered:
+            self._closed = True
+            return False
+        if self._thread_id != threading.get_ident():
+            raise RuntimeError("Extractor can only be closed from the thread that entered it.")
+        assert self._runner is not None
+        assert self._client is not None
+        suppressed = False
+        try:
+            suppressed = bool(self._runner.run(self._agent.__aexit__(*exc_info)))
+        finally:
+            self._client.close()
+            self._runner.close()
+            self._entered = False
+            self._closed = True
+            self._client = None
+            self._runner = None
+        return suppressed
+
+    def close(self) -> None:
+        """Close the owned agent/provider and input HTTP client."""
+        self._close((None, None, None))
+
+    def _ensure_sync_open(self) -> httpx.Client:
+        self._ensure_open(type(self).__name__)
+        if self._thread_id != threading.get_ident():
+            raise RuntimeError("Extractor can only be used from the thread that entered it.")
+        assert self._client is not None
+        return self._client
+
+    def _run_agent(self, inputs: list):
+        assert self._runner is not None
+        return self._runner.run(_run_extraction_async(self._agent, inputs))
+
+    def extract(
+        self,
+        input_file: str | bytes | BinaryIO,
+        *,
+        media_type: str | None = None,
+    ) -> T:
+        """Extract one input using the session's reusable agent and clients."""
+        client = self._ensure_sync_open()
+        inputs = _prepare_run_inputs_sync(
+            input_file,
+            media_type,
+            client,
+            max_input_bytes=self._max_input_bytes,
+        )
+
+        def _once() -> T:
+            return self._validate_output(self._run_agent(inputs).output)
+
+        return _run_with_retries_sync(
+            _once,
+            max_retries=self._retry_policy.max_retries,
+            retry_backoff=self._retry_policy.backoff,
+            retry_max_backoff=self._retry_policy.max_backoff,
+        )
+
+    def extract_with_usage(
+        self,
+        input_file: str | bytes | BinaryIO,
+        *,
+        media_type: str | None = None,
+    ) -> tuple[T, Usage]:
+        """Extract one input and return its successful-call token usage."""
+        client = self._ensure_sync_open()
+        inputs = _prepare_run_inputs_sync(
+            input_file,
+            media_type,
+            client,
+            max_input_bytes=self._max_input_bytes,
+        )
+
+        def _once() -> tuple[T, Usage]:
+            result = self._run_agent(inputs)
+            return self._validate_output(result.output), _usage_from_result(result)
+
+        return _run_with_retries_sync(
+            _once,
+            max_retries=self._retry_policy.max_retries,
+            retry_backoff=self._retry_policy.backoff,
+            retry_max_backoff=self._retry_policy.max_backoff,
+        )
+
+
+class AsyncExtractor(_ExtractorSession[T]):
+    """Reusable async extraction session bound to one event loop."""
+
+    def __init__(
+        self,
+        schema: type[T],
+        model: str | Model | None = None,
+        instructions: str | None = None,
+        *,
+        agent: PydanticAgent | None = None,
+        model_settings: ModelSettings | None = None,
+        timeout: float | None = None,
+        instrument: bool | InstrumentationSettings = False,
+        retry_policy: RetryPolicy | None = None,
+        max_input_bytes: int | None = None,
+        url_timeout: float | None = None,
+    ) -> None:
+        super().__init__(
+            schema,
+            model,
+            instructions,
+            agent=agent,
+            model_settings=model_settings,
+            timeout=timeout,
+            instrument=instrument,
+            retry_policy=retry_policy,
+            max_input_bytes=max_input_bytes,
+            url_timeout=url_timeout,
+        )
+        self._client: httpx.AsyncClient | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    async def __aenter__(self) -> AsyncExtractor[T]:
+        self._ensure_enterable(type(self).__name__)
+        client = httpx.AsyncClient(follow_redirects=False, timeout=self._url_timeout)
+        try:
+            await self._agent.__aenter__()
+        except BaseException:
+            await client.aclose()
+            raise
+        self._client = client
+        self._loop = asyncio.get_running_loop()
+        self._entered = True
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> bool:
+        return await self._close(exc_info)
+
+    async def _close(self, exc_info: tuple[object, ...]) -> bool:
+        if not self._entered:
+            self._closed = True
+            return False
+        if self._loop is not asyncio.get_running_loop():
+            raise RuntimeError(
+                "AsyncExtractor can only be closed from the event loop that entered it."
+            )
+        assert self._client is not None
+        suppressed = False
+        try:
+            suppressed = bool(await self._agent.__aexit__(*exc_info))
+        finally:
+            await self._client.aclose()
+            self._entered = False
+            self._closed = True
+            self._client = None
+            self._loop = None
+        return suppressed
+
+    async def aclose(self) -> None:
+        """Close the owned agent/provider and input HTTP client."""
+        await self._close((None, None, None))
+
+    def _ensure_async_open(self) -> httpx.AsyncClient:
+        self._ensure_open(type(self).__name__)
+        if self._loop is not asyncio.get_running_loop():
+            raise RuntimeError(
+                "AsyncExtractor can only be used from the event loop that entered it."
+            )
+        assert self._client is not None
+        return self._client
+
+    async def extract(
+        self,
+        input_file: str | bytes | BinaryIO,
+        *,
+        media_type: str | None = None,
+    ) -> T:
+        """Extract one input using the session's reusable agent and clients."""
+        client = self._ensure_async_open()
+        inputs = await _prepare_run_inputs_async(
+            input_file,
+            media_type,
+            client,
+            max_input_bytes=self._max_input_bytes,
+        )
+
+        async def _once() -> T:
+            result = await _run_extraction_async(self._agent, inputs)
+            return self._validate_output(result.output)
+
+        return await _run_with_retries_async(
+            _once,
+            max_retries=self._retry_policy.max_retries,
+            retry_backoff=self._retry_policy.backoff,
+            retry_max_backoff=self._retry_policy.max_backoff,
+        )
+
+    async def extract_with_usage(
+        self,
+        input_file: str | bytes | BinaryIO,
+        *,
+        media_type: str | None = None,
+    ) -> tuple[T, Usage]:
+        """Extract one input and return its successful-call token usage."""
+        client = self._ensure_async_open()
+        inputs = await _prepare_run_inputs_async(
+            input_file,
+            media_type,
+            client,
+            max_input_bytes=self._max_input_bytes,
+        )
+
+        async def _once() -> tuple[T, Usage]:
+            result = await _run_extraction_async(self._agent, inputs)
+            return self._validate_output(result.output), _usage_from_result(result)
+
+        return await _run_with_retries_async(
+            _once,
+            max_retries=self._retry_policy.max_retries,
+            retry_backoff=self._retry_policy.backoff,
+            retry_max_backoff=self._retry_policy.max_backoff,
+        )
+
+
 def extract(
     schema: type[T],
-    model: str,
+    model: str | Model,
     input_file: str | bytes | BinaryIO,
     instructions: str | None = None,
     *,
@@ -1113,7 +1597,7 @@ def extract(
 
 def extract_with_usage(
     schema: type[T],
-    model: str,
+    model: str | Model,
     input_file: str | bytes | BinaryIO,
     instructions: str | None = None,
     *,
@@ -1153,7 +1637,7 @@ def extract_with_usage(
 
 async def extract_with_usage_async(
     schema: type[T],
-    model: str,
+    model: str | Model,
     input_file: str | bytes | BinaryIO,
     instructions: str | None = None,
     *,
@@ -1189,7 +1673,7 @@ async def extract_with_usage_async(
 
 async def extract_async(
     schema: type[T],
-    model: str,
+    model: str | Model,
     input_file: str | bytes | BinaryIO,
     instructions: str | None = None,
     *,
@@ -1224,7 +1708,7 @@ async def extract_async(
 
 
 async def _run_with_shared_agent(
-    agent: Agent,
+    agent: PydanticAgent,
     inputs: list,
 ) -> object:
     """Run prepared inputs through a pre-built shared ``Agent``.
@@ -1247,7 +1731,7 @@ async def _cancel_tasks(tasks: Iterable[asyncio.Task[object]]) -> None:
 
 async def _iter_extractions(
     schema: type[T],
-    model: str,
+    model: str | Model,
     input_files: Iterable[str | bytes | BinaryIO],
     instructions: str | None,
     max_concurrency: int,
@@ -1368,7 +1852,7 @@ async def _iter_extractions(
 
 async def _gather_extractions(
     schema: type[T],
-    model: str,
+    model: str | Model,
     input_files: Iterable[str | bytes | BinaryIO],
     instructions: str | None,
     max_concurrency: int,
@@ -1404,7 +1888,7 @@ async def _gather_extractions(
 
 def extract_many(
     schema: type[T],
-    model: str,
+    model: str | Model,
     input_files: Iterable[str | bytes | BinaryIO],
     instructions: str | None = None,
     *,
@@ -1475,7 +1959,7 @@ def extract_many(
 
 async def extract_many_async(
     schema: type[T],
-    model: str,
+    model: str | Model,
     input_files: Iterable[str | bytes | BinaryIO],
     instructions: str | None = None,
     *,
@@ -1505,7 +1989,7 @@ async def extract_many_async(
 
 def iter_extract_many_async(
     schema: type[T],
-    model: str,
+    model: str | Model,
     input_files: Iterable[str | bytes | BinaryIO],
     instructions: str | None = None,
     *,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -29,6 +29,7 @@ ALL_MODULES = [
     "examples.async.async_extract",
     "examples.advanced.extract_with_usage",
     "examples.advanced.retry_extract",
+    "examples.advanced.reusable_sessions",
     "examples.advanced.error_handling",
     "examples.audio.meeting_notes",
 ]
@@ -77,6 +78,12 @@ def test_error_handling_example() -> None:
     assert result.returncode == 0, result.stderr
     assert "UrlFetchError" in result.stdout
     assert "completed successfully" in result.stdout
+
+
+def test_reusable_sessions_example() -> None:
+    result = _run("examples.advanced.reusable_sessions")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.count("ada@example.com") == 2
 
 
 @pytest.mark.integration

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -115,6 +115,9 @@ def test_star_import_exposes_only_existing_names():
     exec("from openextract import *", namespace)
     exported = {name for name in namespace if not name.startswith("_")}
     assert exported == {
+        "Extractor",
+        "AsyncExtractor",
+        "RetryPolicy",
         "extract",
         "extract_async",
         "extract_many",

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,395 @@
+"""Tests for reusable extractor sessions."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import BaseModel
+from pydantic_ai.models.instrumented import InstrumentationSettings
+from pydantic_ai.models.test import TestModel
+
+from openextract import (
+    AsyncExtractor,
+    Extractor,
+    ModelError,
+    RetryPolicy,
+    SchemaValidationError,
+    Usage,
+    extract,
+)
+from openextract.exceptions import ProviderNotInstalledError
+
+
+class Person(BaseModel):
+    name: str
+    age: int
+
+
+class FakeResult:
+    def __init__(self, output, usage=None):
+        self.output = output
+        self._usage = usage or SimpleNamespace(
+            input_tokens=1,
+            output_tokens=2,
+            total_tokens=3,
+        )
+
+    def usage(self):
+        return self._usage
+
+
+class FakeAgent:
+    def __init__(self, outcomes, *, enter_error=None, exit_result=False, exit_error=None):
+        self.outcomes = iter(outcomes)
+        self.enter_error = enter_error
+        self.exit_result = exit_result
+        self.exit_error = exit_error
+        self.enter_count = 0
+        self.exit_count = 0
+        self.run_count = 0
+
+    async def __aenter__(self):
+        self.enter_count += 1
+        if self.enter_error is not None:
+            raise self.enter_error
+        return self
+
+    async def __aexit__(self, *exc_info):
+        self.exit_count += 1
+        if self.exit_error is not None:
+            raise self.exit_error
+        return self.exit_result
+
+    def _next(self):
+        self.run_count += 1
+        outcome = next(self.outcomes)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return FakeResult(outcome)
+
+    def run_sync(self, inputs):
+        return self._next()
+
+    async def run(self, inputs):
+        return self._next()
+
+
+def test_configured_model_works_in_session_and_function_wrapper():
+    model = TestModel(custom_output_args={"name": "Ada", "age": 36})
+
+    with Extractor(Person, model) as extractor:
+        first = extractor.extract(b"first", media_type="text/plain")
+        second = extractor.extract(b"second", media_type="text/plain")
+
+    assert first == second == Person(name="Ada", age=36)
+    assert extract(Person, model, b"one-shot", media_type="text/plain") == first
+
+
+def test_sync_session_reuses_agent_and_clients_and_returns_usage(mocker):
+    agent = FakeAgent([{"name": "Ada", "age": 36}, {"name": "Grace", "age": 85}])
+    agent_factory = mocker.patch("openextract._extract.Agent", return_value=agent)
+    client = MagicMock()
+    client_factory = mocker.patch("openextract._extract.httpx.Client", return_value=client)
+
+    with Extractor(
+        Person,
+        "openai:gpt-test",
+        model_settings={"temperature": 0},
+        timeout=12,
+        instrument=True,
+    ) as extractor:
+        first = extractor.extract(b"one", media_type="text/plain")
+        second, usage = extractor.extract_with_usage(b"two", media_type="text/plain")
+
+    assert first == Person(name="Ada", age=36)
+    assert second == Person(name="Grace", age=85)
+    assert usage == Usage(input_tokens=1, output_tokens=2, total_tokens=3)
+    assert agent_factory.call_count == 1
+    assert agent_factory.call_args.kwargs["model_settings"] == {
+        "temperature": 0,
+        "timeout": 12.0,
+    }
+    assert len(agent_factory.call_args.kwargs["capabilities"]) == 1
+    client_factory.assert_called_once_with(follow_redirects=False, timeout=30.0)
+    client.close.assert_called_once_with()
+    assert agent.enter_count == agent.exit_count == 1
+    assert agent.run_count == 2
+
+
+def test_sync_session_reuses_client_for_url_input(mocker):
+    agent = FakeAgent([{"name": "Ada", "age": 36}])
+    client = MagicMock()
+    mocker.patch("openextract._extract.httpx.Client", return_value=client)
+    read = mocker.patch(
+        "openextract._extract._read_url_with_client",
+        return_value=(b"document", {"content-type": "text/plain"}),
+    )
+
+    with Extractor(Person, agent=agent) as extractor:
+        result = extractor.extract("https://example.com/document")
+
+    assert result == Person(name="Ada", age=36)
+    read.assert_called_once_with(
+        "https://example.com/document",
+        client,
+        limit=50 * 1024 * 1024,
+    )
+
+
+def test_instrumentation_settings_and_validation(mocker):
+    settings = InstrumentationSettings(include_content=False)
+    agent_factory = mocker.patch("openextract._extract.Agent", return_value=FakeAgent([]))
+
+    Extractor(Person, "test", instrument=settings)
+
+    capability = agent_factory.call_args.kwargs["capabilities"][0]
+    assert capability.settings is settings
+    with pytest.raises(TypeError, match="InstrumentationSettings"):
+        Extractor(Person, "test", instrument=object())  # type: ignore[arg-type]
+
+
+def test_configured_model_missing_provider_is_actionable(mocker):
+    model = TestModel(custom_output_args={"name": "Ada", "age": 36})
+    mocker.patch("openextract._extract.Agent", side_effect=ImportError("missing sdk"))
+
+    with pytest.raises(ProviderNotInstalledError, match="configured model.*missing sdk"):
+        Extractor(Person, model)
+
+
+def test_sync_injected_agent_retries_and_validates_output(mocker):
+    retryable = ModelError("temporary", retryable=True)
+    agent = FakeAgent([retryable, {"name": "Ada", "age": 36}])
+    sleep = mocker.patch("openextract._extract.time.sleep")
+
+    with Extractor(
+        Person,
+        agent=agent,
+        retry_policy=RetryPolicy(max_retries=1, backoff=0, max_backoff=0),
+    ) as extractor:
+        assert extractor.extract(b"x", media_type="text/plain") == Person(name="Ada", age=36)
+
+    sleep.assert_called_once_with(0)
+    assert agent.run_count == 2
+
+
+def test_sync_injected_agent_invalid_output_is_mapped():
+    agent = FakeAgent([{"name": "Ada", "age": "invalid"}])
+
+    with (
+        Extractor(Person, agent=agent) as extractor,
+        pytest.raises(SchemaValidationError, match="did not match schema"),
+    ):
+        extractor.extract(b"x", media_type="text/plain")
+
+
+def test_sync_lifecycle_and_thread_guards():
+    agent = FakeAgent([{"name": "Ada", "age": 36}])
+    extractor = Extractor(Person, agent=agent)
+
+    with pytest.raises(RuntimeError, match="context manager"):
+        extractor.extract(b"x", media_type="text/plain")
+
+    with extractor:
+        errors = []
+
+        def use_from_other_thread():
+            try:
+                extractor.extract(b"x", media_type="text/plain")
+            except Exception as exc:  # noqa: BLE001 - asserting the public guard
+                errors.append(exc)
+            try:
+                extractor.close()
+            except Exception as exc:  # noqa: BLE001 - asserting the public guard
+                errors.append(exc)
+
+        thread = threading.Thread(target=use_from_other_thread)
+        thread.start()
+        thread.join()
+        assert isinstance(errors[0], RuntimeError)
+        assert "thread" in str(errors[0])
+        assert isinstance(errors[1], RuntimeError)
+        assert "thread" in str(errors[1])
+
+        with pytest.raises(RuntimeError, match="already entered"):
+            extractor.__enter__()
+
+    with pytest.raises(RuntimeError, match="closed"):
+        extractor.__enter__()
+
+
+def test_sync_close_before_enter_and_context_suppression():
+    closed = Extractor(Person, agent=FakeAgent([]))
+    closed.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        closed.__enter__()
+
+    suppressing = Extractor(Person, agent=FakeAgent([], exit_result=True))
+    with suppressing:
+        raise RuntimeError("suppressed")
+
+
+def test_sync_enter_and_exit_failures_still_close_owned_resources(mocker):
+    enter_client = MagicMock()
+    exit_client = MagicMock()
+    mocker.patch(
+        "openextract._extract.httpx.Client",
+        side_effect=[enter_client, exit_client],
+    )
+    entering = Extractor(Person, agent=FakeAgent([], enter_error=RuntimeError("enter")))
+    with pytest.raises(RuntimeError, match="enter"):
+        entering.__enter__()
+    enter_client.close.assert_called_once_with()
+
+    exiting = Extractor(Person, agent=FakeAgent([], exit_error=RuntimeError("exit")))
+    with pytest.raises(RuntimeError, match="exit"), exiting:
+        pass
+    exit_client.close.assert_called_once_with()
+
+
+@pytest.mark.parametrize("value", [False, 0, -1, float("inf"), "slow"])
+def test_session_timeout_validation(value):
+    with pytest.raises(ValueError, match="finite positive"):
+        Extractor(Person, "test", timeout=value)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="finite positive"):
+        Extractor(Person, "test", url_timeout=value)  # type: ignore[arg-type]
+
+
+def test_session_constructor_rejects_ambiguous_configuration():
+    agent = FakeAgent([])
+    with pytest.raises(TypeError, match="model is required"):
+        Extractor(Person)
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        Extractor(Person, "test", agent=agent)
+    with pytest.raises(ValueError, match="configured on an injected agent"):
+        Extractor(Person, agent=agent, instructions="extract")
+    with pytest.raises(ValueError, match="configured on an injected agent"):
+        Extractor(Person, agent=agent, model_settings={"temperature": 0})
+    with pytest.raises(ValueError, match="configured on an injected agent"):
+        Extractor(Person, agent=agent, timeout=1)
+    with pytest.raises(ValueError, match="instrument"):
+        Extractor(Person, agent=agent, instrument=True)
+    with pytest.raises(TypeError, match="RetryPolicy"):
+        Extractor(Person, "test", retry_policy=object())  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"max_retries": -1},
+        {"backoff": -1},
+        {"max_backoff": float("nan")},
+    ],
+)
+def test_retry_policy_validates_options(kwargs):
+    with pytest.raises(ValueError):
+        RetryPolicy(**kwargs)
+
+
+async def test_sync_extractor_rejects_running_event_loop():
+    extractor = Extractor(Person, agent=FakeAgent([]))
+    with pytest.raises(RuntimeError, match="AsyncExtractor"):
+        extractor.__enter__()
+
+
+async def test_async_configured_model_and_usage():
+    model = TestModel(custom_output_args={"name": "Grace", "age": 85})
+    async with AsyncExtractor(Person, model) as extractor:
+        output, usage = await extractor.extract_with_usage(b"x", media_type="text/plain")
+
+    assert output == Person(name="Grace", age=85)
+    assert usage.total_tokens > 0
+
+
+async def test_async_session_reuses_agent_and_retries(mocker):
+    retryable = ModelError("temporary", retryable=True)
+    agent = FakeAgent([retryable, {"name": "Ada", "age": 36}, {"name": "Grace", "age": 85}])
+    sleep = mocker.patch("openextract._extract.asyncio.sleep")
+    client = MagicMock()
+    client.aclose = AsyncMock()
+    client_factory = mocker.patch("openextract._extract.httpx.AsyncClient", return_value=client)
+
+    async with AsyncExtractor(
+        Person,
+        agent=agent,
+        retry_policy=RetryPolicy(max_retries=1, backoff=0, max_backoff=0),
+        url_timeout=5,
+    ) as extractor:
+        first = await extractor.extract(b"one", media_type="text/plain")
+        second = await extractor.extract(b"two", media_type="text/plain")
+
+    assert first == Person(name="Ada", age=36)
+    assert second == Person(name="Grace", age=85)
+    assert agent.enter_count == agent.exit_count == 1
+    assert agent.run_count == 3
+    sleep.assert_awaited_once_with(0)
+    client_factory.assert_called_once_with(follow_redirects=False, timeout=5.0)
+
+
+async def test_async_invalid_output_and_lifecycle_guards():
+    agent = FakeAgent([{"name": "Ada", "age": "invalid"}])
+    extractor = AsyncExtractor(Person, agent=agent)
+
+    with pytest.raises(RuntimeError, match="context manager"):
+        await extractor.extract(b"x", media_type="text/plain")
+
+    async with extractor:
+        with pytest.raises(SchemaValidationError, match="did not match schema"):
+            await extractor.extract(b"x", media_type="text/plain")
+        with pytest.raises(RuntimeError, match="already entered"):
+            await extractor.__aenter__()
+
+    with pytest.raises(RuntimeError, match="closed"):
+        await extractor.__aenter__()
+
+
+async def test_async_close_before_enter_and_context_suppression():
+    closed = AsyncExtractor(Person, agent=FakeAgent([]))
+    await closed.aclose()
+    with pytest.raises(RuntimeError, match="closed"):
+        await closed.__aenter__()
+
+    suppressing = AsyncExtractor(Person, agent=FakeAgent([], exit_result=True))
+    async with suppressing:
+        raise RuntimeError("suppressed")
+
+
+async def test_async_enter_and_exit_failures_close_client(mocker):
+    enter_client = MagicMock()
+    enter_client.aclose = AsyncMock()
+    exit_client = MagicMock()
+    exit_client.aclose = AsyncMock()
+    mocker.patch(
+        "openextract._extract.httpx.AsyncClient",
+        side_effect=[enter_client, exit_client],
+    )
+
+    entering = AsyncExtractor(Person, agent=FakeAgent([], enter_error=RuntimeError("enter")))
+    with pytest.raises(RuntimeError, match="enter"):
+        await entering.__aenter__()
+    enter_client.aclose.assert_called_once_with()
+
+    exiting = AsyncExtractor(Person, agent=FakeAgent([], exit_error=RuntimeError("exit")))
+    with pytest.raises(RuntimeError, match="exit"):
+        async with exiting:
+            pass
+    exit_client.aclose.assert_called_once_with()
+
+
+def test_async_session_rejects_a_different_event_loop():
+    extractor = AsyncExtractor(Person, agent=FakeAgent([{"name": "Ada", "age": 36}]))
+    first_loop = asyncio.new_event_loop()
+    second_loop = asyncio.new_event_loop()
+    try:
+        first_loop.run_until_complete(extractor.__aenter__())
+        with pytest.raises(RuntimeError, match="event loop"):
+            second_loop.run_until_complete(extractor.extract(b"x", media_type="text/plain"))
+        with pytest.raises(RuntimeError, match="event loop"):
+            second_loop.run_until_complete(extractor.aclose())
+        first_loop.run_until_complete(extractor.aclose())
+    finally:
+        first_loop.close()
+        second_loop.close()


### PR DESCRIPTION
Closes #160

## Summary

- add reusable `Extractor[T]` and `AsyncExtractor[T]` sessions with deterministic context-manager cleanup
- reuse Pydantic AI agents, provider clients, and input-fetch HTTP clients across calls
- accept configured Pydantic AI `Model` instances and safely support fully configured `Agent` injection
- add typed `RetryPolicy`, model settings, request and URL timeouts, and instrumentation controls
- preserve the existing function APIs while extending them to configured models
- document thread/event-loop safety and add sync, async, and dependency-injected examples

## Why

Repeated one-shot extractions rebuilt configuration and provider clients, and string-only model identifiers prevented callers from supplying custom endpoints, programmatic credentials, instrumentation, or test models. The new sessions make lifecycle and reuse explicit while retaining existing behavior.

## Validation

- `ruff format .`
- `ruff check .`
- `ty check`
- `python scripts/check_api_reference.py`
- `pytest -q --cov=openextract --cov-report=term-missing --cov-fail-under=100`
- 349 passed, 5 skipped, 100% statement and branch coverage